### PR TITLE
add MediaControllerDisposer for managing the MediaControllerFuture release in onStop

### DIFF
--- a/androidApp/src/main/java/com/techbeloved/hymnbook/MainActivity.kt
+++ b/androidApp/src/main/java/com/techbeloved/hymnbook/MainActivity.kt
@@ -7,14 +7,23 @@ import androidx.activity.enableEdgeToEdge
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.tooling.preview.Preview
 import com.techbeloved.hymnbook.shared.App
+import com.techbeloved.media.DefaultMediaControllerDisposer
+import com.techbeloved.media.MediaControllerDisposer
 
-class MainActivity : ComponentActivity() {
+class MainActivity : ComponentActivity(),
+    MediaControllerDisposer by DefaultMediaControllerDisposer() {
+
     override fun onCreate(savedInstanceState: Bundle?) {
         enableEdgeToEdge()
         super.onCreate(savedInstanceState)
         setContent {
             App()
         }
+    }
+
+    override fun onStop() {
+        onDispose()
+        super.onStop()
     }
 }
 

--- a/modules/media/src/androidMain/kotlin/com/techbeloved/media/DefaultMediaControllerDisposer.kt
+++ b/modules/media/src/androidMain/kotlin/com/techbeloved/media/DefaultMediaControllerDisposer.kt
@@ -1,0 +1,15 @@
+package com.techbeloved.media
+
+import androidx.media3.session.MediaController
+import com.google.common.util.concurrent.ListenableFuture
+
+class DefaultMediaControllerDisposer: MediaControllerDisposer {
+    override var controllerFuture: ListenableFuture<MediaController>? = null
+
+    @Synchronized
+    override fun onDispose() {
+        controllerFuture?.let { MediaController.releaseFuture(it) }
+        controllerFuture = null
+    }
+
+}

--- a/modules/media/src/androidMain/kotlin/com/techbeloved/media/MediaControllerDisposer.kt
+++ b/modules/media/src/androidMain/kotlin/com/techbeloved/media/MediaControllerDisposer.kt
@@ -1,0 +1,20 @@
+package com.techbeloved.media
+
+import androidx.media3.session.MediaController
+import com.google.common.util.concurrent.ListenableFuture
+
+/**
+ * It's a bit tricky handling release of the controller from a composable and coroutine scope.
+ * The activity onStop might complete before the coroutine cancellation is completed. We thus end up
+ * with leaking activity.
+ *
+ * With this interface, we can handled release of the controller from the activity directly. This
+ * ensures that the controller is disconnected before onStop execution is completed.
+ */
+interface MediaControllerDisposer {
+
+     var controllerFuture: ListenableFuture<MediaController>?
+
+
+     fun onDispose()
+}

--- a/modules/media/src/androidMain/kotlin/com/techbeloved/media/PlaybackState.android.kt
+++ b/modules/media/src/androidMain/kotlin/com/techbeloved/media/PlaybackState.android.kt
@@ -26,7 +26,6 @@ actual fun rememberPlaybackController(playbackState: PlaybackState): PlaybackCon
     val context = LocalContext.current
 
     var playbackController: PlaybackController? by remember { mutableStateOf(null) }
-
     val lifecycle = LocalLifecycleOwner.current
     LaunchedEffect(Unit) {
         lifecycle.repeatOnLifecycle(Lifecycle.State.STARTED) {
@@ -41,11 +40,12 @@ actual fun rememberPlaybackController(playbackState: PlaybackState): PlaybackCon
                     scope = this,
                     state = playbackState,
                 )
+                (context as MediaControllerDisposer).controllerFuture = controllerFuture
                 awaitCancellation()
             } finally {
                 playbackController = null
-                println("Release mediaController")
-                MediaController.releaseFuture(controllerFuture)
+                (context as MediaControllerDisposer).onDispose()
+                println("Release mediaController - onDispose")
             }
         }
     }


### PR DESCRIPTION
add MediaControllerDisposer for managing the MediaControllerFuture release in onStop

The activity has to implement this. A default implementation is already provided.

Fixes the frequent crash from MediaController leakage during onStop