### PR TITLE
Refactor: Enhance playback controls and settings UI

### DIFF
--- a/config/detekt/detekt.yml
+++ b/config/detekt/detekt.yml
@@ -168,9 +168,9 @@ complexity:
   TooManyFunctions:
     active: true
     excludes: ['**/test/**', '**/androidTest/**', '**/commonTest/**', '**/jvmTest/**', '**/androidUnitTest/**', '**/androidInstrumentedTest/**', '**/jsTest/**', '**/iosTest/**']
-    thresholdInFiles: 11
-    thresholdInClasses: 11
-    thresholdInInterfaces: 11
+    thresholdInFiles: 20
+    thresholdInClasses: 20
+    thresholdInInterfaces: 20
     thresholdInObjects: 11
     thresholdInEnums: 11
     ignoreDeprecated: false

--- a/modules/media/src/androidMain/kotlin/com/techbeloved/media/AndroidPlaybackController.kt
+++ b/modules/media/src/androidMain/kotlin/com/techbeloved/media/AndroidPlaybackController.kt
@@ -26,6 +26,8 @@ class AndroidPlaybackController(
             itemIndex = mediaController.currentMediaItemIndex
             position = mediaController.currentPosition
             mediaId = mediaController.currentMediaItem?.mediaId
+            // Convert to percent
+            playbackSpeed = mediaController.playbackParameters.speed.rateToPercent
             updateDuration()
         }
 
@@ -69,6 +71,10 @@ class AndroidPlaybackController(
                 }
                 if (events.contains(Player.EVENT_TIMELINE_CHANGED)) {
                     updateDuration()
+                }
+
+                if (events.contains(Player.EVENT_PLAYBACK_PARAMETERS_CHANGED)) {
+                    state.playbackSpeed = mediaController.playbackParameters.speed.rateToPercent
                 }
             }
         }
@@ -129,5 +135,9 @@ class AndroidPlaybackController(
 
     override fun playWhenReady() {
         mediaController.playWhenReady = true
+    }
+
+    override fun changePlaybackSpeed(speed: Int) {
+        mediaController.setPlaybackSpeed(speed.ratePercentToFloat)
     }
 }

--- a/modules/media/src/androidMain/kotlin/com/techbeloved/media/DummyPlaybackController.kt
+++ b/modules/media/src/androidMain/kotlin/com/techbeloved/media/DummyPlaybackController.kt
@@ -32,4 +32,8 @@ class DummyPlaybackController(private val playbackState: PlaybackState) : Playba
     override fun playWhenReady() {
         if (playbackState.playerState == PlayerState.Ready) play()
     }
+
+    override fun changePlaybackSpeed(speed: Int) {
+        playbackState.playbackSpeed = speed
+    }
 }

--- a/modules/media/src/commonMain/kotlin/com/techbeloved/media/PlaybackController.kt
+++ b/modules/media/src/commonMain/kotlin/com/techbeloved/media/PlaybackController.kt
@@ -21,4 +21,6 @@ interface PlaybackController {
     fun prepare()
 
     fun playWhenReady()
+
+    fun changePlaybackSpeed(speed: Int)
 }

--- a/modules/media/src/commonMain/kotlin/com/techbeloved/media/PlaybackSpeedExt.kt
+++ b/modules/media/src/commonMain/kotlin/com/techbeloved/media/PlaybackSpeedExt.kt
@@ -1,0 +1,4 @@
+package com.techbeloved.media
+
+val Int.ratePercentToFloat: Float get() = this / 100f
+val Float.rateToPercent: Int get() = (this * 100).toInt()

--- a/modules/media/src/commonMain/kotlin/com/techbeloved/media/PlaybackState.kt
+++ b/modules/media/src/commonMain/kotlin/com/techbeloved/media/PlaybackState.kt
@@ -33,6 +33,7 @@ class PlaybackState(
     position: Long = 0L,
     duration: Long = 0L,
     itemIndex: Int = 0,
+    playbackSpeed: Int = 100,
     playerState: PlayerState = PlayerState.Idle,
     mediaId: String? = null,
 ) {
@@ -46,13 +47,14 @@ class PlaybackState(
     var duration by mutableLongStateOf(duration)
         internal set
     var playerState by mutableStateOf(playerState)
+    var playbackSpeed by mutableStateOf(playbackSpeed)
+        internal set
 
     /**
      * The currently playing media id.
      */
     var mediaId by mutableStateOf(mediaId)
         internal set
-
 
     companion object {
         val Saver: Saver<PlaybackState, *> = listSaver(
@@ -64,6 +66,7 @@ class PlaybackState(
                     it.duration,
                     it.playerState,
                     it.mediaId,
+                    it.playbackSpeed,
                 )
             },
             restore = {
@@ -74,9 +77,9 @@ class PlaybackState(
                     duration = it[3] as Long,
                     playerState = it[4] as PlayerState,
                     mediaId = it[5] as String?,
+                    playbackSpeed = it[6] as Int,
                 )
             }
         )
     }
-
 }

--- a/modules/media/src/iosMain/kotlin/com/techbeloved/media/IosMediaPlayer.kt
+++ b/modules/media/src/iosMain/kotlin/com/techbeloved/media/IosMediaPlayer.kt
@@ -11,4 +11,6 @@ interface IosMediaPlayer {
     fun prepare()
 
     fun onDispose()
+
+    fun changePlaybackSpeed(speed: Float)
 }

--- a/modules/media/src/iosMain/kotlin/com/techbeloved/media/IosPlaybackController.kt
+++ b/modules/media/src/iosMain/kotlin/com/techbeloved/media/IosPlaybackController.kt
@@ -75,6 +75,10 @@ class IosPlaybackController(
         player?.play()
     }
 
+    override fun changePlaybackSpeed(speed: Int) {
+        player?.changePlaybackSpeed(speed.ratePercentToFloat)
+    }
+
     private fun playCurrentItem() {
         prepare()
         player?.play()

--- a/shared/src/androidAndDesktop/kotlin/com/techbeloved/hymnbook/shared/ext/FloatExt.androidAndDesktop.kt
+++ b/shared/src/androidAndDesktop/kotlin/com/techbeloved/hymnbook/shared/ext/FloatExt.androidAndDesktop.kt
@@ -1,0 +1,3 @@
+package com.techbeloved.hymnbook.shared.ext
+
+public actual fun Float.decimalPlaces(decimalCount: Int): String = "%.2f".format(this)

--- a/shared/src/androidMain/kotlin/com/techbeloved/hymnbook/shared/ui/AppPreviews.kt
+++ b/shared/src/androidMain/kotlin/com/techbeloved/hymnbook/shared/ui/AppPreviews.kt
@@ -12,10 +12,8 @@ import com.techbeloved.media.AudioItem
 @Preview
 @Composable
 private fun BottomControlsUiPreview() {
-
     MaterialTheme {
         BottomControlsUi(
-            title = "Hymn 10",
             audioItem = AudioItem(
                 absolutePath = "files/sample2.mp3",
                 relativePath = "relative/path",
@@ -26,6 +24,7 @@ private fun BottomControlsUiPreview() {
             ),
             onPreviousButtonClick = {},
             onNextButtonClick = {},
+            onShowSettingsBottomSheet = {},
         )
     }
 }

--- a/shared/src/commonMain/kotlin/com/techbeloved/hymnbook/shared/ext/FloatExt.kt
+++ b/shared/src/commonMain/kotlin/com/techbeloved/hymnbook/shared/ext/FloatExt.kt
@@ -1,0 +1,10 @@
+package com.techbeloved.hymnbook.shared.ext
+
+private const val NearestFiveMultiplier = 5
+public val Int.percentToNearestFive: String
+    get() {
+        val roundedToNearestFive = (this / NearestFiveMultiplier) * NearestFiveMultiplier
+        return (roundedToNearestFive / 100f).decimalPlaces(decimalCount = 2)
+    }
+
+public expect fun Float.decimalPlaces(decimalCount: Int): String

--- a/shared/src/commonMain/kotlin/com/techbeloved/hymnbook/shared/preferences/InMemoryPreferences.kt
+++ b/shared/src/commonMain/kotlin/com/techbeloved/hymnbook/shared/preferences/InMemoryPreferences.kt
@@ -16,7 +16,6 @@ internal class InMemoryPreferences(private val store: MutableMap<String, Any?> =
 
         if (other.store.size != store.size) return false
 
-
         return other.store.all { otherEntry ->
             store[otherEntry.key]?.let { value ->
                 when (val otherVal = otherEntry.value) {
@@ -24,7 +23,7 @@ internal class InMemoryPreferences(private val store: MutableMap<String, Any?> =
                     else -> otherVal == value
                 }
             } ?: false
-        }.also { println("Equals $it") }
+        }
     }
 
     override fun hashCode(): Int {

--- a/shared/src/commonMain/kotlin/com/techbeloved/hymnbook/shared/preferences/SongPreferences.kt
+++ b/shared/src/commonMain/kotlin/com/techbeloved/hymnbook/shared/preferences/SongPreferences.kt
@@ -34,6 +34,5 @@ internal data class SongPreferences(
             key = floatPreferencesKey("song.FontSize"),
             defaultValue = 20f,
         )
-
     }
 }

--- a/shared/src/commonMain/kotlin/com/techbeloved/hymnbook/shared/ui/detail/BottomControlsUi.kt
+++ b/shared/src/commonMain/kotlin/com/techbeloved/hymnbook/shared/ui/detail/BottomControlsUi.kt
@@ -2,16 +2,16 @@ package com.techbeloved.hymnbook.shared.ui.detail
 
 import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.animateContentSize
-import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.outlined.KeyboardArrowDown
 import androidx.compose.material.icons.rounded.ChevronLeft
 import androidx.compose.material.icons.rounded.ChevronRight
 import androidx.compose.material.icons.rounded.Pause
@@ -21,7 +21,6 @@ import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.IconButtonDefaults
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
@@ -32,10 +31,10 @@ import androidx.compose.runtime.setValue
 import androidx.compose.runtime.snapshotFlow
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.clip
 import androidx.compose.ui.unit.dp
 import com.techbeloved.media.AudioItem
 import com.techbeloved.media.PlaybackController
+import com.techbeloved.media.PlaybackState
 import com.techbeloved.media.PlayerState
 import com.techbeloved.media.rememberPlaybackController
 import com.techbeloved.media.rememberPlaybackState
@@ -43,54 +42,63 @@ import kotlinx.collections.immutable.persistentListOf
 
 @Composable
 internal fun BottomControlsUi(
-    title: String,
     audioItem: AudioItem?,
     onPreviousButtonClick: () -> Unit,
     onNextButtonClick: () -> Unit,
+    onShowSettingsBottomSheet: () -> Unit,
     modifier: Modifier = Modifier,
+    playbackState: PlaybackState = rememberPlaybackState(),
+    controller: PlaybackController? = rememberPlaybackController(playbackState),
 ) {
     Row(
         modifier = modifier
             .fillMaxWidth()
-            .height(44.dp)
-            .padding(horizontal = 16.dp),
+            .padding(horizontal = 8.dp),
         horizontalArrangement = Arrangement.spacedBy(16.dp),
         verticalAlignment = Alignment.CenterVertically,
     ) {
         Row(
-            modifier = Modifier.weight(1f)
-                .clip(RoundedCornerShape(22.dp))
-                .background(MaterialTheme.colorScheme.surfaceVariant)
-                .animateContentSize(),
-            horizontalArrangement = Arrangement.SpaceBetween,
+            modifier = Modifier.animateContentSize(),
+            horizontalArrangement = Arrangement.spacedBy(32.dp),
             verticalAlignment = Alignment.CenterVertically,
         ) {
             IconButton(onClick = onPreviousButtonClick) {
                 Icon(imageVector = Icons.Rounded.ChevronLeft, contentDescription = "Previous")
             }
-            Text(
-                text = title,
-                style = MaterialTheme.typography.titleSmall,
-            )
+            if (audioItem != null) {
+                PlayButton(
+                    audioItem = audioItem,
+                    playbackState = playbackState,
+                    controller = controller,
+                )
+            } else {
+                DisabledPlayButton()
+            }
             IconButton(onClick = onNextButtonClick) {
                 Icon(imageVector = Icons.Rounded.ChevronRight, contentDescription = "Next")
             }
+
+        }
+        Spacer(Modifier.weight(1f))
+        IconButton(
+            onClick = onShowSettingsBottomSheet,
+        ) {
+            Icon(
+                imageVector = Icons.Outlined.KeyboardArrowDown,
+                contentDescription = "Show more controls"
+            )
         }
 
-        if (audioItem != null) {
-            PlayButton(audioItem)
-        }
     }
 }
 
 @Composable
 private fun PlayButton(
     audioItem: AudioItem,
+    playbackState: PlaybackState,
+    controller: PlaybackController?,
     modifier: Modifier = Modifier,
 ) {
-    val playbackState = rememberPlaybackState()
-    val controller = rememberPlaybackController(playbackState)
-
     var progressVisible by remember { mutableStateOf(false) }
     var progress by remember { mutableFloatStateOf(0f) }
 
@@ -121,7 +129,7 @@ private fun PlayButton(
     }
     AnimatedVisibility(
         visible = controller != null,
-        modifier = modifier.size(44.dp),
+        modifier = modifier.size(48.dp),
     ) {
         IconButton(
             onClick = {
@@ -164,6 +172,27 @@ private fun PlayButton(
             CircularProgressIndicator(strokeWidth = 2.dp, progress = { progress })
         }
     }
+}
+
+@Composable
+private fun DisabledPlayButton(modifier: Modifier = Modifier) {
+    Box(modifier = modifier.size(44.dp)) {
+        IconButton(
+            onClick = {},
+            enabled = false,
+            modifier = Modifier.fillMaxSize(),
+            colors = IconButtonDefaults.iconButtonColors(
+                containerColor = MaterialTheme.colorScheme.surfaceVariant
+            ),
+        ) {
+            Icon(
+                imageVector = Icons.Rounded.PlayArrow,
+                contentDescription = "Playable media not available",
+            )
+        }
+        CircularProgressIndicator(strokeWidth = 2.dp, progress = { 0f })
+    }
+
 }
 
 private fun PlaybackController.playNew(audioItem: AudioItem) {

--- a/shared/src/commonMain/kotlin/com/techbeloved/hymnbook/shared/ui/detail/DetailBottomSheetState.kt
+++ b/shared/src/commonMain/kotlin/com/techbeloved/hymnbook/shared/ui/detail/DetailBottomSheetState.kt
@@ -1,9 +1,9 @@
 package com.techbeloved.hymnbook.shared.ui.detail
 
-import com.techbeloved.hymnbook.shared.ui.settings.NowPlayingBottomSettingsState
+import com.techbeloved.hymnbook.shared.preferences.SongPreferences
 
 internal sealed interface DetailBottomSheetState {
-    data object Hidden: DetailBottomSheetState
+    data object Hidden : DetailBottomSheetState
 
-    data class Show(val settingsState: NowPlayingBottomSettingsState): DetailBottomSheetState
+    data class Show(val preferences: SongPreferences) : DetailBottomSheetState
 }

--- a/shared/src/commonMain/kotlin/com/techbeloved/hymnbook/shared/ui/detail/MusicSpeedUtil.kt
+++ b/shared/src/commonMain/kotlin/com/techbeloved/hymnbook/shared/ui/detail/MusicSpeedUtil.kt
@@ -1,0 +1,15 @@
+package com.techbeloved.hymnbook.shared.ui.detail
+
+private const val PlaybackSpeedStep = 5
+private const val MinSpeed = 50
+private const val MaxSpeed = 200
+
+internal fun changeMusicSpeed(currentSpeed: Int, isIncrease: Boolean): Int {
+    val change = if (isIncrease) {
+        PlaybackSpeedStep
+    } else {
+        -PlaybackSpeedStep
+    }
+    return (currentSpeed + change)
+        .coerceIn(MinSpeed, MaxSpeed)
+}

--- a/shared/src/commonMain/kotlin/com/techbeloved/hymnbook/shared/ui/search/HomeSearchBar.kt
+++ b/shared/src/commonMain/kotlin/com/techbeloved/hymnbook/shared/ui/search/HomeSearchBar.kt
@@ -26,7 +26,7 @@ internal fun HomeSearchBar(onOpenSearchScreen: () -> Unit) {
             .padding(horizontal = 16.dp)
             .height(48.dp),
         onClick = {
-           onOpenSearchScreen()
+            onOpenSearchScreen()
         },
         color = MaterialTheme.colorScheme.surfaceContainerHigh,
         shape = CircleShape,
@@ -48,7 +48,7 @@ internal fun HomeSearchBar(onOpenSearchScreen: () -> Unit) {
             )
 
             IconButton(
-                onClick = { println("Open speed dial") }
+                onClick = { /* Open speed dial */ }
             ) {
                 Icon(
                     imageVector = Icons.Rounded.Dialpad,

--- a/shared/src/commonMain/kotlin/com/techbeloved/hymnbook/shared/ui/settings/NowPlayingBottomSettingsState.kt
+++ b/shared/src/commonMain/kotlin/com/techbeloved/hymnbook/shared/ui/settings/NowPlayingBottomSettingsState.kt
@@ -1,5 +1,0 @@
-package com.techbeloved.hymnbook.shared.ui.settings
-
-internal sealed interface NowPlayingBottomSettingsState {
-    data object Default : NowPlayingBottomSettingsState
-}

--- a/shared/src/iosMain/kotlin/com/techbeloved/hymnbook/shared/ext/FloatExt.ios.kt
+++ b/shared/src/iosMain/kotlin/com/techbeloved/hymnbook/shared/ext/FloatExt.ios.kt
@@ -1,0 +1,17 @@
+package com.techbeloved.hymnbook.shared.ext
+
+import platform.Foundation.NSNumber
+import platform.Foundation.NSNumberFormatter
+import platform.Foundation.NSNumberFormatterDecimalStyle
+
+public actual fun Float.decimalPlaces(decimalCount: Int): String {
+    // Format the float with the specified number of decimal places
+    val numberFormatter = NSNumberFormatter()
+    numberFormatter.numberStyle = NSNumberFormatterDecimalStyle
+    numberFormatter.minimumFractionDigits = decimalCount.toULong()
+    numberFormatter.maximumFractionDigits = decimalCount.toULong()
+
+    // Convert the float to NSNumber
+    val number = NSNumber(this.toDouble())
+    return numberFormatter.stringFromNumber(number) ?: ""
+}


### PR DESCRIPTION
This commit introduces several improvements to the playback controls and settings in the song detail screen:

- **Playback Speed Control:**
    - Added functionality to change playback speed for both MIDI and regular audio.
    - Integrated playback speed controls into the NowPlayingSettingsBottomSheet.
    - Updated `PlaybackController` and platform-specific implementations to support speed changes.
    - Display playback speed as a percentage (e.g., 1.00X, 0.75X).
- **UI Enhancements for Song Detail Screen:**
    - Refined the `BottomControlsUi`:
        - Removed the title display from the bottom controls.
        - Added an icon button to show/hide the settings bottom sheet.
        - Ensured the play button is disabled if no audio item is available.
    - Improved `NowPlayingSettingsBottomSheet`:
        - Reorganized settings into sections with dividers.
        - Added controls for toggling sheet music display.
        - Display current font size next to zoom controls.
        - Display current playback speed.
    - Adjusted top app bar scroll behavior to `enterAlwaysScrollBehavior`.
    - Removed the segmented button for display mode selection from the top app bar (now handled in the bottom sheet).
- **Code Refinements:**
    - Updated detekt's `TooManyFunctions` threshold to 20 for files, classes, and interfaces.
    - Introduced utility functions for formatting floats to a specific number of decimal places (`Float.decimalPlaces`) and converting playback speed percentages.
    - Refactored `DetailBottomSheetState` to directly hold `SongPreferences`.
    - Ensured `PlaybackState` tracks `playbackSpeed`.
- **iOS Specific:**
    - Updated iOS MIDI player to respect initial playback speed and allow changes.
    - Updated iOS media player to support playback speed changes.