### PR TITLE
#102 Refactor: Introduce songbook selection and sorting in Home screen

### DIFF
--- a/shared/src/commonMain/kotlin/com/techbeloved/hymnbook/shared/model/SongFilter.kt
+++ b/shared/src/commonMain/kotlin/com/techbeloved/hymnbook/shared/model/SongFilter.kt
@@ -21,10 +21,10 @@ internal data class SongFilter(
             orderByTitle = false,
         )
 
-        fun songbookFilter(songbook: String): SongFilter = SongFilter(
+        fun songbookFilter(songbook: String, sortByTitle: Boolean = false): SongFilter = SongFilter(
             topics = emptyList(),
             songbooks = listOf(songbook),
-            orderByTitle = false,
+            orderByTitle = sortByTitle,
         )
     }
 }

--- a/shared/src/commonMain/kotlin/com/techbeloved/hymnbook/shared/songbooks/GetAllSongbooksUseCase.kt
+++ b/shared/src/commonMain/kotlin/com/techbeloved/hymnbook/shared/songbooks/GetAllSongbooksUseCase.kt
@@ -1,0 +1,16 @@
+package com.techbeloved.hymnbook.shared.songbooks
+
+import com.techbeloved.hymnbook.Database
+import com.techbeloved.hymnbook.SongbookEntity
+import com.techbeloved.hymnbook.shared.dispatcher.DispatchersProvider
+import kotlinx.coroutines.withContext
+import me.tatarka.inject.annotations.Inject
+
+internal class GetAllSongbooksUseCase @Inject constructor(
+    private val database: Database,
+    private val dispatchersProvider: DispatchersProvider,
+) {
+    suspend operator fun invoke(): List<SongbookEntity> = withContext(dispatchersProvider.io()) {
+        database.songbookEntityQueries.getAll().executeAsList()
+    }
+}

--- a/shared/src/commonMain/kotlin/com/techbeloved/hymnbook/shared/ui/AppScaffold.kt
+++ b/shared/src/commonMain/kotlin/com/techbeloved/hymnbook/shared/ui/AppScaffold.kt
@@ -3,6 +3,7 @@
 package com.techbeloved.hymnbook.shared.ui
 
 import androidx.compose.foundation.layout.RowScope
+import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.material3.CenterAlignedTopAppBar
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
@@ -28,6 +29,7 @@ internal fun AppTopBar(
     showUpButton: Boolean = true,
     scrollBehaviour: TopAppBarScrollBehavior? = null,
     containerColor: Color = MaterialTheme.colorScheme.surface,
+    windowInsets: WindowInsets = TopAppBarDefaults.windowInsets,
     actions: @Composable (RowScope.() -> Unit) = {},
 ) {
     CenterAlignedTopAppBar(
@@ -60,5 +62,6 @@ internal fun AppTopBar(
             titleContentColor = MaterialTheme.colorScheme.onSurface,
             actionIconContentColor = MaterialTheme.colorScheme.onSurfaceVariant,
         ),
+        windowInsets = windowInsets,
     )
 }

--- a/shared/src/commonMain/kotlin/com/techbeloved/hymnbook/shared/ui/home/HomeScreenState.kt
+++ b/shared/src/commonMain/kotlin/com/techbeloved/hymnbook/shared/ui/home/HomeScreenState.kt
@@ -1,0 +1,25 @@
+package com.techbeloved.hymnbook.shared.ui.home
+
+import com.techbeloved.hymnbook.SongbookEntity
+import com.techbeloved.hymnbook.shared.model.SongTitle
+import kotlinx.collections.immutable.ImmutableList
+import kotlinx.collections.immutable.persistentListOf
+
+internal data class HomeScreenState(
+    val songTitles: ImmutableList<SongTitle>,
+    val songbooks: ImmutableList<SongbookEntity>,
+    val currentSongbook: SongbookEntity?,
+    val isLoading: Boolean,
+    val sortBy: SortBy,
+) {
+
+    companion object {
+        val EmptyLoading = HomeScreenState(
+            songTitles = persistentListOf(),
+            songbooks = persistentListOf(),
+            currentSongbook = null,
+            isLoading = true,
+            sortBy = SortBy.Number,
+        )
+    }
+}

--- a/shared/src/commonMain/kotlin/com/techbeloved/hymnbook/shared/ui/home/HomeTabScreen.kt
+++ b/shared/src/commonMain/kotlin/com/techbeloved/hymnbook/shared/ui/home/HomeTabScreen.kt
@@ -1,23 +1,42 @@
 package com.techbeloved.hymnbook.shared.ui.home
 
-import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.width
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.twotone.Sort
+import androidx.compose.material.icons.twotone.Search
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.ExposedDropdownMenuBox
+import androidx.compose.material3.ExposedDropdownMenuDefaults
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.MenuAnchorType
 import androidx.compose.material3.NavigationBar
+import androidx.compose.material3.RadioButton
 import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.input.nestedscroll.nestedScroll
+import androidx.compose.ui.unit.dp
 import androidx.lifecycle.viewmodel.compose.viewModel
 import com.techbeloved.hymnbook.shared.model.SongTitle
 import com.techbeloved.hymnbook.shared.ui.AppTopBar
-import com.techbeloved.hymnbook.shared.ui.listing.HymnListingUi
-import com.techbeloved.hymnbook.shared.ui.search.HomeSearchBar
-import kotlinx.collections.immutable.ImmutableList
+import com.techbeloved.hymnbook.shared.ui.listing.SongListingUi
+import com.techbeloved.hymnbook.shared.ui.songbook.SongbookSelector
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -33,11 +52,28 @@ internal fun HomeTabScreen(
         topBar = {
             AppTopBar(
                 showUpButton = false,
+                scrollBehaviour = scrollBehavior,
                 titleContent = {
-                    HomeSearchBar {
-                        onOpenSearch()
+                    if (!state.isLoading) {
+                        SongbookSelector(
+                            songbooks = state.songbooks,
+                            selectedSongbook = state.currentSongbook,
+                            onSongbookSelected = viewModel::onUpdateSongbook,
+                        )
                     }
                 },
+                actions = {
+                    Spacer(Modifier.width(8.dp))
+                    IconButton(onClick = onOpenSearch, modifier = Modifier) {
+                        Icon(imageVector = Icons.TwoTone.Search, contentDescription = "Search")
+                    }
+                    Spacer(Modifier.width(12.dp))
+                    SortByButton(
+                        onSortBy = viewModel::onUpdateSortBy,
+                        sortBy = state.sortBy,
+                    )
+                    Spacer(Modifier.width(16.dp))
+                }
             )
         },
         bottomBar = {
@@ -49,27 +85,69 @@ internal fun HomeTabScreen(
         },
         modifier = modifier,
     ) { innerPadding ->
-        HomeUi(
-            state = state,
-            modifier = Modifier
-                .nestedScroll(scrollBehavior.nestedScrollConnection),
-            contentPadding = innerPadding,
-            onSongItemClicked = onSongItemClicked,
-        )
+        if (state.isLoading) {
+            Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+                CircularProgressIndicator()
+            }
+        } else {
+            SongListingUi(
+                songItems = state.songTitles,
+                modifier = Modifier
+                    .nestedScroll(scrollBehavior.nestedScrollConnection)
+                    .fillMaxSize(),
+                contentPadding = innerPadding,
+                onSongItemClicked = onSongItemClicked,
+            )
+        }
     }
 }
 
+@ExperimentalMaterial3Api
 @Composable
-private fun HomeUi(
-    state: ImmutableList<SongTitle>,
-    onSongItemClicked: (SongTitle) -> Unit,
-    contentPadding: PaddingValues,
+private fun SortByButton(
+    sortBy: SortBy,
+    onSortBy: (SortBy) -> Unit,
     modifier: Modifier = Modifier,
 ) {
-    HymnListingUi(
-        hymnItems = state,
-        modifier = modifier.fillMaxSize(),
-        contentPadding = contentPadding,
-        onSongItemClicked = onSongItemClicked,
-    )
+    var isExpanded by remember { mutableStateOf(false) }
+    ExposedDropdownMenuBox(
+        expanded = isExpanded,
+        onExpandedChange = { isExpanded = it },
+        modifier = modifier,
+    ) {
+        IconButton(
+            onClick = {},
+            modifier = Modifier.menuAnchor(type = MenuAnchorType.PrimaryNotEditable),
+        ) {
+            Icon(
+                imageVector = Icons.AutoMirrored.TwoTone.Sort,
+                contentDescription = "Sort By",
+            )
+        }
+
+        ExposedDropdownMenu(
+            expanded = isExpanded,
+            onDismissRequest = { isExpanded = false },
+            matchTextFieldWidth = false,
+            shape = MaterialTheme.shapes.medium,
+        ) {
+            SortBy.entries.forEach { entry ->
+                DropdownMenuItem(
+                    text = { Text(text = entry.label) },
+                    onClick = {
+                        onSortBy(entry)
+                        isExpanded = false
+                    },
+                    contentPadding = ExposedDropdownMenuDefaults.ItemContentPadding,
+                    trailingIcon = {
+                        RadioButton(selected = entry == sortBy, onClick = null)
+                    }
+                )
+                if (entry != SortBy.entries.last()) {
+                    HorizontalDivider()
+                }
+            }
+
+        }
+    }
 }

--- a/shared/src/commonMain/kotlin/com/techbeloved/hymnbook/shared/ui/home/SortBy.kt
+++ b/shared/src/commonMain/kotlin/com/techbeloved/hymnbook/shared/ui/home/SortBy.kt
@@ -1,0 +1,6 @@
+package com.techbeloved.hymnbook.shared.ui.home
+
+internal enum class SortBy(val label: String) {
+    Number(label = "Sort by Number"),
+    Title(label = "Sort by Title"),
+}

--- a/shared/src/commonMain/kotlin/com/techbeloved/hymnbook/shared/ui/listing/SongListingUi.kt
+++ b/shared/src/commonMain/kotlin/com/techbeloved/hymnbook/shared/ui/listing/SongListingUi.kt
@@ -15,15 +15,15 @@ import com.techbeloved.hymnbook.shared.model.SongTitle
 import kotlinx.collections.immutable.ImmutableList
 
 @Composable
-internal fun HymnListingUi(
-    hymnItems: ImmutableList<SongTitle>,
+internal fun SongListingUi(
+    songItems: ImmutableList<SongTitle>,
     onSongItemClicked: (SongTitle) -> Unit,
     contentPadding: PaddingValues,
     modifier: Modifier = Modifier,
 ) {
 
     LazyColumn(modifier = modifier, contentPadding = contentPadding) {
-        items(hymnItems, SongTitle::id) { item ->
+        items(songItems, SongTitle::id) { item ->
             ListItem(
                 modifier = Modifier.clickable {
                     onSongItemClicked(item)

--- a/shared/src/commonMain/kotlin/com/techbeloved/hymnbook/shared/ui/search/AppSearchBar.kt
+++ b/shared/src/commonMain/kotlin/com/techbeloved/hymnbook/shared/ui/search/AppSearchBar.kt
@@ -52,7 +52,9 @@ internal fun AppSearchBar(
                         .focusRequester(focusRequester),
                     value = query,
                     onValueChange = { if (query.length < maxChar) onQueryChange(it) },
-                    textStyle = MaterialTheme.typography.bodyMedium,
+                    textStyle = MaterialTheme.typography.bodyMedium.copy(
+                        color = MaterialTheme.colorScheme.onSurface,
+                    ),
                     keyboardOptions = KeyboardOptions(
                         keyboardType = KeyboardType.Text,
                         imeAction = ImeAction.Search,
@@ -67,7 +69,10 @@ internal fun AppSearchBar(
                             enabled = true,
                             singleLine = true,
                             placeholder = {
-                                Text(text = placeholderText)
+                                Text(
+                                    text = placeholderText,
+                                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                                )
                             },
                             visualTransformation = VisualTransformation.None,
                             interactionSource = interactionSource,

--- a/shared/src/commonMain/kotlin/com/techbeloved/hymnbook/shared/ui/search/SearchUi.kt
+++ b/shared/src/commonMain/kotlin/com/techbeloved/hymnbook/shared/ui/search/SearchUi.kt
@@ -16,7 +16,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.input.nestedscroll.nestedScroll
 import com.techbeloved.hymnbook.shared.model.SongTitle
-import com.techbeloved.hymnbook.shared.ui.listing.HymnListingUi
+import com.techbeloved.hymnbook.shared.ui.listing.SongListingUi
 import kotlinx.collections.immutable.ImmutableList
 
 @OptIn(ExperimentalMaterial3Api::class)
@@ -80,8 +80,8 @@ private fun SearchResults(
     contentPadding: PaddingValues,
     modifier: Modifier = Modifier,
 ) {
-    HymnListingUi(
-        hymnItems = results,
+    SongListingUi(
+        songItems = results,
         contentPadding = contentPadding,
         modifier = modifier,
         onSongItemClicked = onSongItemClicked,

--- a/shared/src/commonMain/kotlin/com/techbeloved/hymnbook/shared/ui/songbook/SongbookSelector.kt
+++ b/shared/src/commonMain/kotlin/com/techbeloved/hymnbook/shared/ui/songbook/SongbookSelector.kt
@@ -1,0 +1,114 @@
+@file:OptIn(ExperimentalMaterial3Api::class)
+
+package com.techbeloved.hymnbook.shared.ui.songbook
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.twotone.KeyboardArrowDown
+import androidx.compose.material3.DropdownMenuItem
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.ExposedDropdownMenuBox
+import androidx.compose.material3.ExposedDropdownMenuDefaults
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.MenuAnchorType
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.rotate
+import androidx.compose.ui.unit.dp
+import com.techbeloved.hymnbook.SongbookEntity
+import com.techbeloved.hymnbook.shared.ui.theme.AppTheme
+import kotlinx.collections.immutable.ImmutableList
+import kotlinx.collections.immutable.persistentListOf
+import org.jetbrains.compose.ui.tooling.preview.Preview
+
+@Composable
+internal fun SongbookSelector(
+    songbooks: ImmutableList<SongbookEntity>,
+    selectedSongbook: SongbookEntity?,
+    onSongbookSelected: (SongbookEntity) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    var isExpanded by remember { mutableStateOf(false) }
+
+    ExposedDropdownMenuBox(
+        expanded = isExpanded,
+        onExpandedChange = { isExpanded = it },
+        modifier = modifier,
+    ) {
+        Row(
+            modifier = Modifier
+                .menuAnchor(type = MenuAnchorType.PrimaryNotEditable)
+                .background(
+                    color = MaterialTheme.colorScheme.surfaceVariant,
+                    shape = MaterialTheme.shapes.small
+                )
+                .clickable(onClickLabel = "Select Songbook") { }
+                .padding(horizontal = 12.dp, vertical = 8.dp),
+        ) {
+            Text(
+                text = selectedSongbook?.name.orEmpty(),
+                modifier = Modifier.weight(1f),
+                maxLines = 1,
+            )
+            Spacer(Modifier.width(width = 8.dp))
+            TrailingIcon(expanded = isExpanded)
+        }
+        ExposedDropdownMenu(
+            expanded = isExpanded,
+            onDismissRequest = { isExpanded = false },
+        ) {
+            songbooks.forEach { songbook ->
+                DropdownMenuItem(
+                    text = { Text(songbook.name) },
+                    onClick = {
+                        onSongbookSelected(songbook)
+                        isExpanded = false
+                    },
+                    contentPadding = ExposedDropdownMenuDefaults.ItemContentPadding,
+                )
+            }
+
+        }
+    }
+}
+
+@Composable
+private fun TrailingIcon(
+    expanded: Boolean,
+    modifier: Modifier = Modifier,
+) {
+    Icon(
+        imageVector = Icons.TwoTone.KeyboardArrowDown,
+        contentDescription = null,
+        modifier = modifier.rotate(degrees = if (expanded) 180f else 0f),
+    )
+}
+
+@Composable
+@Preview
+private fun PreviewSongbookSelector() {
+    val songbook = SongbookEntity(
+        publisher = "publisher1",
+        name = "Songbook 1"
+    )
+    AppTheme {
+        SongbookSelector(
+            songbooks = persistentListOf(
+                songbook,
+            ),
+            onSongbookSelected = {},
+            selectedSongbook = songbook,
+        )
+    }
+}

--- a/shared/src/commonMain/kotlin/com/techbeloved/hymnbook/shared/ui/songs/FilteredSongsScreen.kt
+++ b/shared/src/commonMain/kotlin/com/techbeloved/hymnbook/shared/ui/songs/FilteredSongsScreen.kt
@@ -16,7 +16,7 @@ import androidx.lifecycle.viewmodel.compose.viewModel
 import com.techbeloved.hymnbook.shared.model.SongFilter
 import com.techbeloved.hymnbook.shared.model.SongTitle
 import com.techbeloved.hymnbook.shared.ui.AppTopBar
-import com.techbeloved.hymnbook.shared.ui.listing.HymnListingUi
+import com.techbeloved.hymnbook.shared.ui.listing.SongListingUi
 import dev.chrisbanes.haze.HazeState
 import dev.chrisbanes.haze.hazeEffect
 import dev.chrisbanes.haze.materials.ExperimentalHazeMaterialsApi
@@ -68,8 +68,8 @@ private fun FilteredSongsUi(
         },
         modifier = modifier,
     ) { innerPadding ->
-        HymnListingUi(
-            hymnItems = state.songs,
+        SongListingUi(
+            songItems = state.songs,
             contentPadding = innerPadding,
             modifier = Modifier.fillMaxSize(),
             onSongItemClicked = onSongItemClicked,

--- a/shared/src/commonMain/sqldelight/com/techbeloved/hymnbook/SongEntity.sq
+++ b/shared/src/commonMain/sqldelight/com/techbeloved/hymnbook/SongEntity.sq
@@ -89,7 +89,7 @@ LEFT JOIN SongbookSongs AS sbs ON sd.id = sbs.song_id
 WHERE ts.topic IN :topicNames
 AND sbs.songbook IN :songbookNames
 GROUP BY sd.id
-ORDER BY (CASE WHEN :orderByTitle THEN sd.title ELSE sd.songbookEntries END);
+ORDER BY (CASE WHEN :orderByTitle THEN sd.title ELSE CAST(sbs.entry AS REAL) END);
 
 
 filterSongsByTopics:
@@ -99,17 +99,16 @@ LEFT JOIN TopicSongs AS ts ON sd.id = ts.song_id
 LEFT JOIN SongbookSongs AS sbs ON sd.id = sbs.song_id
 WHERE ts.topic IN :topicNames
 GROUP BY sd.id
-ORDER BY (CASE WHEN :orderByTitle THEN sd.title ELSE sd.songbookEntries END);
+ORDER BY (CASE WHEN :orderByTitle THEN sd.title ELSE CAST(sbs.entry AS REAL) END);
 
 
 filterSongsBySongbooks:
 SELECT DISTINCT sd.id, sd.title, sd.alternate_title, sbs.songbook, sbs.entry
 FROM SongDetail AS sd
-LEFT JOIN TopicSongs AS ts ON sd.id = ts.song_id
-LEFT JOIN SongbookSongs AS sbs ON sd.id = sbs.song_id
+JOIN SongbookSongs AS sbs ON sd.id = sbs.song_id
 AND sbs.songbook IN :songbookNames
 GROUP BY sd.id
-ORDER BY (CASE WHEN :orderByTitle THEN sd.title ELSE sd.songbookEntries END);
+ORDER BY (CASE WHEN :orderByTitle THEN sd.title ELSE CAST(sbs.entry AS REAL) END);
 
 
 filterSongs:
@@ -118,7 +117,7 @@ FROM SongDetail AS sd
 LEFT JOIN TopicSongs AS ts ON sd.id = ts.song_id
 LEFT JOIN SongbookSongs AS sbs ON sd.id = sbs.song_id
 GROUP BY sd.id
-ORDER BY (CASE WHEN :orderByTitle THEN sd.title ELSE sd.songbookEntries END);
+ORDER BY (CASE WHEN :orderByTitle THEN sd.title ELSE CAST(sbs.entry AS REAL) END);
 
 getAllSongs:
 SELECT * FROM SongDetail;


### PR DESCRIPTION
#102 Refactor: Introduce songbook selection and sorting in Home screen

This commit introduces significant enhancements to the Home screen:

- **Songbook Selection:**
    - Added `SongbookSelector` composable to allow users to switch between different songbooks.
    - `HomeScreenModel` now fetches and manages a list of available songbooks.
    - The selected songbook filters the displayed hymn list.
- **Sorting Options:**
    - Added a "Sort By" button with options to sort hymns by "Number" or "Title".
    - `HomeScreenModel` now handles sorting preferences.
- **UI and State Management:**
    - Introduced `HomeScreenState` to manage the complex state of the Home screen, including song lists, songbooks, loading status, and sort order.
    - Updated `AppTopBar` in `HomeTabScreen` to accommodate the new songbook selector and sort button.
    - Display a loading indicator while assets are being prepared.
- **Database and Use Cases:**
    - Added `GetAllSongbooksUseCase` to retrieve songbook data.
    - Modified SQL queries in `SongEntity.sq` to correctly order by number (as float) or title based on the new `orderByTitle` parameter, particularly for `filterSongsBySongbooks`.
- **Code Renaming:**
    - Renamed `HymnListingUi` to `SongListingUi` for better clarity.
- **Minor UI Tweaks:**
    - Adjusted `AppSearchBar` text style and placeholder color for better visibility.
    - Removed the search bar from the `HomeTabScreen` top bar; search is now accessed via an icon button.