### PR TITLE
104-playlist-management

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -11,7 +11,7 @@ androidx_core_ktx = "1.16.0"
 androidx_datastore = "1.1.7"
 androidx_hilt_compiler = "1.2.0"
 androidx_hilt_work = "1.2.0"
-androidx_lifecycle = "2.9.0"
+androidx_lifecycle = "2.9.1"
 androidx_media3 = "1.7.1"
 androidx_test_junit = "1.2.1"
 androidx_work = "2.10.1"
@@ -185,6 +185,7 @@ rxjava = { module = "io.reactivex.rxjava2:rxjava", version.ref = "rxjava" }
 rxrelay = { module = "com.jakewharton.rxrelay2:rxrelay", version.ref = "rxrelay" }
 slf4j-api = { module = "org.slf4j:slf4j-api", version.ref = "slf4jApi" }
 snippety = { module = "com.github.fueled:snippety", version.ref = "snippety" }
+sqldelight-coroutines-extensions = { group = "app.cash.sqldelight", name = "coroutines-extensions", version.ref = "sqlDelight" }
 sqldelight-runtime = { group = "app.cash.sqldelight", name = "runtime", version.ref = "sqlDelight" }
 sqldelight-adapters = { group = "app.cash.sqldelight", name = "primitive-adapters", version.ref = "sqlDelight" }
 sqldelight-android = { group = "app.cash.sqldelight", name = "android-driver", version.ref = "sqlDelight" }
@@ -207,6 +208,7 @@ coil-network = { group = "io.coil-kt.coil3", name = "coil-network-ktor3", versio
 
 jetbrains-navigation-compose = { module = "org.jetbrains.androidx.navigation:navigation-compose", version.ref = "jetbrainsNavigation"}
 jetbrains-viewmodel-compose = { module = "org.jetbrains.androidx.lifecycle:lifecycle-viewmodel-compose", version.ref = "jetbrainsViewModel"}
+jetbrains-runtime-compose = { module = "org.jetbrains.androidx.lifecycle:lifecycle-runtime-compose", version.ref = "jetbrainsViewModel"}
 
 test-androidx-junit = { group = "androidx.test.ext", name = "junit", version.ref = "androidx_test_junit" }
 test-ui-test-junit = { group = "androidx.compose.ui", name = "ui-test-junit4", version.ref = "compose_ui" }

--- a/iosApp/iosApp.xcodeproj/xcshareddata/xcschemes/iosApp.xcscheme
+++ b/iosApp/iosApp.xcodeproj/xcshareddata/xcschemes/iosApp.xcscheme
@@ -1,17 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1510"
-   version = "1.7">
-   <BuildAction
-      parallelizeBuildables = "YES"
-      buildImplicitDependencies = "YES">
+   version = "1.3">
+   <BuildAction>
       <BuildActionEntries>
          <BuildActionEntry
-            buildForTesting = "YES"
-            buildForRunning = "YES"
-            buildForProfiling = "YES"
-            buildForArchiving = "YES"
-            buildForAnalyzing = "YES">
+            buildForRunning = "YES">
             <BuildableReference
                BuildableIdentifier = "primary"
                BlueprintIdentifier = "7555FF7A242A565900829871"
@@ -22,25 +15,11 @@
          </BuildActionEntry>
       </BuildActionEntries>
    </BuildAction>
-   <TestAction
-      buildConfiguration = "Debug"
-      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
-      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      shouldUseLaunchSchemeArgsEnv = "YES"
-      shouldAutocreateTestPlan = "YES">
-   </TestAction>
    <LaunchAction
-      buildConfiguration = "Debug"
-      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
-      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      launchStyle = "0"
       useCustomWorkingDirectory = "NO"
-      ignoresPersistentStateOnLaunch = "NO"
-      debugDocumentVersioning = "YES"
-      debugServiceExtension = "internal"
+      buildConfiguration = "Debug"
       allowLocationSimulation = "YES">
-      <BuildableProductRunnable
-         runnableDebuggingMode = "0">
+      <BuildableProductRunnable>
          <BuildableReference
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "7555FF7A242A565900829871"
@@ -50,28 +29,4 @@
          </BuildableReference>
       </BuildableProductRunnable>
    </LaunchAction>
-   <ProfileAction
-      buildConfiguration = "Release"
-      shouldUseLaunchSchemeArgsEnv = "YES"
-      savedToolIdentifier = ""
-      useCustomWorkingDirectory = "NO"
-      debugDocumentVersioning = "YES">
-      <BuildableProductRunnable
-         runnableDebuggingMode = "0">
-         <BuildableReference
-            BuildableIdentifier = "primary"
-            BlueprintIdentifier = "7555FF7A242A565900829871"
-            BuildableName = "iosApp.app"
-            BlueprintName = "iosApp"
-            ReferencedContainer = "container:iosApp.xcodeproj">
-         </BuildableReference>
-      </BuildableProductRunnable>
-   </ProfileAction>
-   <AnalyzeAction
-      buildConfiguration = "Debug">
-   </AnalyzeAction>
-   <ArchiveAction
-      buildConfiguration = "Release"
-      revealArchiveInOrganizer = "YES">
-   </ArchiveAction>
 </Scheme>

--- a/shared/build.gradle.kts
+++ b/shared/build.gradle.kts
@@ -58,6 +58,7 @@ kotlin {
             implementation(compose.components.uiToolingPreview)
             implementation(libs.jetbrains.navigation.compose)
             implementation(libs.jetbrains.viewmodel.compose)
+            implementation(libs.jetbrains.runtime.compose)
             implementation(libs.kotlinx.collections.immutable)
             implementation(libs.kotlinx.serialization)
             implementation(libs.kotlinx.io)
@@ -65,6 +66,7 @@ kotlin {
             implementation(libs.coroutines)
 
             // Sqldelight
+            implementation(libs.sqldelight.coroutines.extensions)
             implementation(libs.sqldelight.runtime)
             implementation(libs.sqldelight.adapters)
 

--- a/shared/src/commonMain/kotlin/com/techbeloved/hymnbook/shared/data/ColumnAdapters.kt
+++ b/shared/src/commonMain/kotlin/com/techbeloved/hymnbook/shared/data/ColumnAdapters.kt
@@ -2,7 +2,6 @@ package com.techbeloved.hymnbook.shared.data
 
 import app.cash.sqldelight.ColumnAdapter
 import kotlinx.datetime.Instant
-import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.Json
 
 internal inline fun <reified T> listColumnAdapter(json: Json) =
@@ -19,7 +18,7 @@ internal inline fun <reified T : Any> jsonColumnAdapter(json: Json) =
         override fun encode(value: T): String = json.encodeToString(value)
     }
 
-internal inline fun dateColumnAdapter() = object : ColumnAdapter<Instant, Long> {
+internal fun dateColumnAdapter() = object : ColumnAdapter<Instant, Long> {
     override fun decode(databaseValue: Long): Instant = Instant.fromEpochMilliseconds(databaseValue)
 
     override fun encode(value: Instant): Long = value.toEpochMilliseconds()

--- a/shared/src/commonMain/kotlin/com/techbeloved/hymnbook/shared/di/AppComponent.kt
+++ b/shared/src/commonMain/kotlin/com/techbeloved/hymnbook/shared/di/AppComponent.kt
@@ -16,6 +16,7 @@ import com.techbeloved.hymnbook.shared.ui.detail.SongDetailPagerModel
 import com.techbeloved.hymnbook.shared.ui.detail.SongDetailScreenModel
 import com.techbeloved.hymnbook.shared.ui.home.HomeScreenModel
 import com.techbeloved.hymnbook.shared.ui.playlist.PlaylistsViewModel
+import com.techbeloved.hymnbook.shared.ui.playlist.add.AddEditPlaylistViewModel
 import com.techbeloved.hymnbook.shared.ui.search.SearchScreenModel
 import com.techbeloved.hymnbook.shared.ui.songs.FilteredSongsViewModel
 import com.techbeloved.hymnbook.shared.ui.topics.TopicsViewModel
@@ -66,6 +67,7 @@ internal interface AppComponent {
     @Provides
     fun provideInstantProvider(instantProvider: DefaultInstantProvider): InstantProvider =
         instantProvider
+    fun addNewPlaylistViewModelFactory(): AddEditPlaylistViewModel.Factory
 
     companion object
 }

--- a/shared/src/commonMain/kotlin/com/techbeloved/hymnbook/shared/di/AppComponent.kt
+++ b/shared/src/commonMain/kotlin/com/techbeloved/hymnbook/shared/di/AppComponent.kt
@@ -15,6 +15,7 @@ import com.techbeloved.hymnbook.shared.time.InstantProvider
 import com.techbeloved.hymnbook.shared.ui.detail.SongDetailPagerModel
 import com.techbeloved.hymnbook.shared.ui.detail.SongDetailScreenModel
 import com.techbeloved.hymnbook.shared.ui.home.HomeScreenModel
+import com.techbeloved.hymnbook.shared.ui.playlist.PlaylistsViewModel
 import com.techbeloved.hymnbook.shared.ui.search.SearchScreenModel
 import com.techbeloved.hymnbook.shared.ui.songs.FilteredSongsViewModel
 import com.techbeloved.hymnbook.shared.ui.topics.TopicsViewModel
@@ -39,6 +40,8 @@ internal interface AppComponent {
     fun searchScreenModel(): SearchScreenModel
 
     fun topicsViewModel(): TopicsViewModel
+
+    fun playlistsViewModel(): PlaylistsViewModel
 
     @Provides
     fun assetFileSource(): AssetFileSourceProvider = assetFileSourceProvider

--- a/shared/src/commonMain/kotlin/com/techbeloved/hymnbook/shared/di/Injector.kt
+++ b/shared/src/commonMain/kotlin/com/techbeloved/hymnbook/shared/di/Injector.kt
@@ -5,6 +5,7 @@ import app.cash.sqldelight.EnumColumnAdapter
 import app.cash.sqldelight.db.SqlDriver
 import com.techbeloved.hymnbook.Database
 import com.techbeloved.hymnbook.MediaFile
+import com.techbeloved.hymnbook.PlaylistEntity
 import com.techbeloved.hymnbook.SheetMusicEntity
 import com.techbeloved.hymnbook.SongEntity
 import com.techbeloved.hymnbook.shared.data.dateColumnAdapter
@@ -52,9 +53,13 @@ internal object Injector {
             MediaFileAdapter = MediaFile.Adapter(EnumColumnAdapter()),
             SheetMusicEntityAdapter = SheetMusicEntity.Adapter(EnumColumnAdapter()),
             SongEntityAdapter = SongEntity.Adapter(
-                listColumnAdapter(json),
-                dateColumnAdapter(),
-                dateColumnAdapter(),
+                lyricsAdapter = listColumnAdapter(json),
+                createdAdapter = dateColumnAdapter(),
+                modifiedAdapter = dateColumnAdapter(),
+            ),
+            PlaylistEntityAdapter = PlaylistEntity.Adapter(
+                createdAdapter = dateColumnAdapter(),
+                modifiedAdapter = dateColumnAdapter(),
             ),
         )
     }

--- a/shared/src/commonMain/kotlin/com/techbeloved/hymnbook/shared/model/playlist/PlaylistItem.kt
+++ b/shared/src/commonMain/kotlin/com/techbeloved/hymnbook/shared/model/playlist/PlaylistItem.kt
@@ -1,0 +1,12 @@
+package com.techbeloved.hymnbook.shared.model.playlist
+
+import kotlinx.datetime.Instant
+
+internal data class PlaylistItem(
+    val id: Long,
+    val name: String,
+    val description: String?,
+    val imageUrl: String?,
+    val created: Instant,
+    val updated: Instant,
+)

--- a/shared/src/commonMain/kotlin/com/techbeloved/hymnbook/shared/model/playlist/SongInPlaylist.kt
+++ b/shared/src/commonMain/kotlin/com/techbeloved/hymnbook/shared/model/playlist/SongInPlaylist.kt
@@ -1,0 +1,8 @@
+package com.techbeloved.hymnbook.shared.model.playlist
+
+internal data class SongInPlaylist(
+    val id: Long,
+    val title: String,
+    val alternateTitle: String?,
+    val playlistId: Long,
+)

--- a/shared/src/commonMain/kotlin/com/techbeloved/hymnbook/shared/openlyrics/SaveOpenLyricsUseCase.kt
+++ b/shared/src/commonMain/kotlin/com/techbeloved/hymnbook/shared/openlyrics/SaveOpenLyricsUseCase.kt
@@ -92,6 +92,8 @@ internal class SaveOpenLyricsUseCase @Inject constructor(
                 copyright = song.properties.copyright,
                 search_title = song.properties.titles.joinToString(separator = " ") { it.value },
                 search_lyrics = lyrics.joinToString(separator = " ") { it.content },
+                search_songbook = song.properties.songbooks
+                    ?.joinToString(separator = " ") { it.entry.orEmpty() } ?: "",
                 modified = created,
                 id = existingSong.id,
             )
@@ -105,6 +107,8 @@ internal class SaveOpenLyricsUseCase @Inject constructor(
                 copyright = song.properties.copyright,
                 search_title = song.properties.titles.joinToString(separator = " ") { it.value },
                 search_lyrics = lyrics.joinToString(separator = " ") { it.content },
+                search_songbook = song.properties.songbooks
+                    ?.joinToString(separator = " ") { it.entry.orEmpty() } ?: "",
                 created = created,
                 modified = created,
                 id = null,

--- a/shared/src/commonMain/kotlin/com/techbeloved/hymnbook/shared/playlist/CreatePlaylistUseCase.kt
+++ b/shared/src/commonMain/kotlin/com/techbeloved/hymnbook/shared/playlist/CreatePlaylistUseCase.kt
@@ -1,0 +1,26 @@
+package com.techbeloved.hymnbook.shared.playlist
+
+import com.techbeloved.hymnbook.Database
+import com.techbeloved.hymnbook.shared.time.InstantProvider
+import kotlinx.coroutines.NonCancellable
+import kotlinx.coroutines.withContext
+import me.tatarka.inject.annotations.Inject
+
+internal class CreatePlaylistUseCase @Inject constructor(
+    private val database: Database,
+    private val instantProvider: InstantProvider,
+) {
+    suspend operator fun invoke(name: String, description: String?, imageUrl: String?): Long =
+        withContext(NonCancellable) {
+            val time = instantProvider.get()
+            database.playlistEntityQueries.insert(
+                id = null,
+                name = name,
+                description = description,
+                image_url = imageUrl,
+                created = time,
+                modified = time,
+            ).await()
+            database.playlistEntityQueries.lastInsertRowId().executeAsOne()
+        }
+}

--- a/shared/src/commonMain/kotlin/com/techbeloved/hymnbook/shared/playlist/DeletePlaylistUseCase.kt
+++ b/shared/src/commonMain/kotlin/com/techbeloved/hymnbook/shared/playlist/DeletePlaylistUseCase.kt
@@ -1,0 +1,15 @@
+package com.techbeloved.hymnbook.shared.playlist
+
+import com.techbeloved.hymnbook.Database
+import com.techbeloved.hymnbook.shared.dispatcher.DispatchersProvider
+import kotlinx.coroutines.withContext
+import me.tatarka.inject.annotations.Inject
+
+internal class DeletePlaylistUseCase @Inject constructor(
+    private val database: Database,
+    private val dispatchersProvider: DispatchersProvider,
+) {
+    suspend operator fun invoke(playlistId: Long): Unit = withContext(dispatchersProvider.io()) {
+        database.playlistEntityQueries.delete(playlistId).await()
+    }
+}

--- a/shared/src/commonMain/kotlin/com/techbeloved/hymnbook/shared/playlist/GetPlaylistByIdUseCase.kt
+++ b/shared/src/commonMain/kotlin/com/techbeloved/hymnbook/shared/playlist/GetPlaylistByIdUseCase.kt
@@ -1,0 +1,27 @@
+package com.techbeloved.hymnbook.shared.playlist
+
+import com.techbeloved.hymnbook.Database
+import com.techbeloved.hymnbook.shared.dispatcher.DispatchersProvider
+import com.techbeloved.hymnbook.shared.model.playlist.PlaylistItem
+import kotlinx.coroutines.withContext
+import me.tatarka.inject.annotations.Inject
+
+internal class GetPlaylistByIdUseCase @Inject constructor(
+    private val database: Database,
+    private val dispatchersProvider: DispatchersProvider,
+) {
+    suspend operator fun invoke(playlistId: Long): PlaylistItem =
+        withContext(dispatchersProvider.io()) {
+            database.playlistEntityQueries.getById(playlistId) { id, name, description, imageUrl, created, modified ->
+                PlaylistItem(
+                    id = id,
+                    name = name,
+                    description = description,
+                    imageUrl = imageUrl,
+                    created = created,
+                    updated = modified,
+                )
+
+            }.executeAsOne()
+        }
+}

--- a/shared/src/commonMain/kotlin/com/techbeloved/hymnbook/shared/playlist/GetPlaylistsUseCase.kt
+++ b/shared/src/commonMain/kotlin/com/techbeloved/hymnbook/shared/playlist/GetPlaylistsUseCase.kt
@@ -1,0 +1,26 @@
+package com.techbeloved.hymnbook.shared.playlist
+
+import app.cash.sqldelight.coroutines.asFlow
+import app.cash.sqldelight.coroutines.mapToList
+import com.techbeloved.hymnbook.Database
+import com.techbeloved.hymnbook.shared.dispatcher.DispatchersProvider
+import com.techbeloved.hymnbook.shared.model.playlist.PlaylistItem
+import kotlinx.coroutines.flow.Flow
+import me.tatarka.inject.annotations.Inject
+
+internal class GetPlaylistsUseCase @Inject constructor(
+    private val database: Database,
+    private val dispatchersProvider: DispatchersProvider,
+) {
+    operator fun invoke(): Flow<List<PlaylistItem>> =
+        database.playlistEntityQueries.getAll { id, name, description, imageUrl, created, updated ->
+            PlaylistItem(
+                id = id,
+                name = name,
+                description = description,
+                imageUrl = imageUrl,
+                created = created,
+                updated = updated,
+            )
+        }.asFlow().mapToList(context = dispatchersProvider.io())
+}

--- a/shared/src/commonMain/kotlin/com/techbeloved/hymnbook/shared/playlist/GetSongsInPlaylistUseCase.kt
+++ b/shared/src/commonMain/kotlin/com/techbeloved/hymnbook/shared/playlist/GetSongsInPlaylistUseCase.kt
@@ -1,0 +1,24 @@
+package com.techbeloved.hymnbook.shared.playlist
+
+import com.techbeloved.hymnbook.Database
+import com.techbeloved.hymnbook.shared.dispatcher.DispatchersProvider
+import com.techbeloved.hymnbook.shared.model.playlist.SongInPlaylist
+import kotlinx.coroutines.withContext
+import me.tatarka.inject.annotations.Inject
+
+internal class GetSongsInPlaylistUseCase @Inject constructor(
+    private val database: Database,
+    private val dispatchersProvider: DispatchersProvider,
+) {
+    suspend operator fun invoke(playlistId: Long): List<SongInPlaylist> =
+        withContext(dispatchersProvider.io()) {
+            database.playlistSongsQueries.getSongsInPlaylist(playlistId) { id, title, alternateTitle ->
+                SongInPlaylist(
+                    id = id,
+                    title = title,
+                    alternateTitle = alternateTitle,
+                    playlistId = playlistId,
+                )
+            }.executeAsList()
+        }
+}

--- a/shared/src/commonMain/kotlin/com/techbeloved/hymnbook/shared/playlist/UpdatePlaylistUseCase.kt
+++ b/shared/src/commonMain/kotlin/com/techbeloved/hymnbook/shared/playlist/UpdatePlaylistUseCase.kt
@@ -1,0 +1,31 @@
+package com.techbeloved.hymnbook.shared.playlist
+
+import com.techbeloved.hymnbook.Database
+import com.techbeloved.hymnbook.shared.dispatcher.DispatchersProvider
+import com.techbeloved.hymnbook.shared.time.InstantProvider
+import kotlinx.coroutines.withContext
+import me.tatarka.inject.annotations.Inject
+
+internal class UpdatePlaylistUseCase @Inject constructor(
+    private val database: Database,
+    private val dispatchersProvider: DispatchersProvider,
+    private val instantProvider: InstantProvider,
+) {
+
+    suspend operator fun invoke(
+        playlistId: Long,
+        name: String,
+        description: String?,
+        imageUrl: String?
+    ): Long = withContext(dispatchersProvider.io()) {
+        database.playlistEntityQueries.update(
+            playlistId = playlistId,
+            name = name,
+            description = description,
+            imageUrl = imageUrl,
+            modified = instantProvider.get(),
+        ).await()
+        playlistId
+    }
+
+}

--- a/shared/src/commonMain/kotlin/com/techbeloved/hymnbook/shared/search/SearchSongsUseCase.kt
+++ b/shared/src/commonMain/kotlin/com/techbeloved/hymnbook/shared/search/SearchSongsUseCase.kt
@@ -12,7 +12,13 @@ internal class SearchSongsUseCase @Inject constructor(
 ) {
     suspend operator fun invoke(searchQuery: String): List<SongTitle> =
         withContext(dispatchersProvider.io()) {
-            database.songEntityQueries.searchSongs(searchQuery, ::SongTitle)
-                .executeAsList()
+            // check if search query contains only digits, then use the searchSongbookEntry
+            if (searchQuery.matches(regex = "\\d+".toRegex())) {
+                database.songEntityQueries.searchSongbookEntry(searchQuery, ::SongTitle)
+                    .executeAsList()
+            } else {
+                database.songEntityQueries.searchSongs(searchQuery, ::SongTitle)
+                    .executeAsList()
+            }
         }
 }

--- a/shared/src/commonMain/kotlin/com/techbeloved/hymnbook/shared/ui/dialog/AppDialog.kt
+++ b/shared/src/commonMain/kotlin/com/techbeloved/hymnbook/shared/ui/dialog/AppDialog.kt
@@ -1,0 +1,42 @@
+package com.techbeloved.hymnbook.shared.ui.dialog
+
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.Button
+import androidx.compose.material3.FilledTonalButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+
+@Composable
+internal fun AppDialog(
+    title: String,
+    content: String,
+    positiveText: String,
+    negativeText: String,
+    onDismiss: () -> Unit,
+    onConfirm: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        confirmButton = {
+            Button(
+                onClick = onConfirm,
+            ) {
+                Text(text = positiveText)
+            }
+        },
+        dismissButton = {
+            FilledTonalButton(
+                onClick = onDismiss,
+            ) {
+                Text(text = negativeText)
+            }
+        },
+        shape = MaterialTheme.shapes.medium,
+        title = { Text(text = title) },
+        text = { Text(text = content) },
+        modifier = modifier,
+    )
+}

--- a/shared/src/commonMain/kotlin/com/techbeloved/hymnbook/shared/ui/home/HomeGraph.kt
+++ b/shared/src/commonMain/kotlin/com/techbeloved/hymnbook/shared/ui/home/HomeGraph.kt
@@ -18,6 +18,7 @@ import com.techbeloved.hymnbook.shared.ui.detail.SongDetailScreen
 import com.techbeloved.hymnbook.shared.ui.discover.DiscoverTabScreen
 import com.techbeloved.hymnbook.shared.ui.more.MoreTabScreen
 import com.techbeloved.hymnbook.shared.ui.playlist.PlayListTabScreen
+import com.techbeloved.hymnbook.shared.ui.playlist.add.AddEditPlaylistDialog
 import com.techbeloved.hymnbook.shared.ui.search.SearchScreen
 import com.techbeloved.hymnbook.shared.ui.songs.FilteredSongsScreen
 import kotlinx.collections.immutable.persistentListOf
@@ -97,7 +98,7 @@ internal fun NavGraphBuilder.addHomeRoutes(navController: NavHostController) =
 
         composable<TopLevelDestination.Playlists> {
             PlayListTabScreen {
-                // Navigate to add playlist screen
+                navController.navigate(AddEditPlaylistDialog(playlistId = null))
             }
         }
 

--- a/shared/src/commonMain/kotlin/com/techbeloved/hymnbook/shared/ui/home/HomeGraph.kt
+++ b/shared/src/commonMain/kotlin/com/techbeloved/hymnbook/shared/ui/home/HomeGraph.kt
@@ -96,7 +96,9 @@ internal fun NavGraphBuilder.addHomeRoutes(navController: NavHostController) =
         }
 
         composable<TopLevelDestination.Playlists> {
-            PlayListTabScreen()
+            PlayListTabScreen {
+                // Navigate to add playlist screen
+            }
         }
 
         composable<TopLevelDestination.More> {

--- a/shared/src/commonMain/kotlin/com/techbeloved/hymnbook/shared/ui/home/HomeScreenModel.kt
+++ b/shared/src/commonMain/kotlin/com/techbeloved/hymnbook/shared/ui/home/HomeScreenModel.kt
@@ -55,15 +55,16 @@ internal class HomeScreenModel @Inject constructor(
         songbooks,
     ) { assetsReady, sortBy, selectedSongbook, songbooks ->
         if (assetsReady) {
+            val songbook = selectedSongbook ?: songbooks.firstOrNull()
             HomeScreenState(
                 songTitles = getFilteredSongTitlesUseCase(
                     songFilter = SongFilter.songbookFilter(
-                        songbook = selectedSongbook?.name ?: songbooks.first().name,
+                        songbook = songbook?.name.orEmpty(),
                         sortByTitle = sortBy == SortBy.Title,
                     )
                 ).toImmutableList(),
                 songbooks = songbooks,
-                currentSongbook = selectedSongbook ?: songbooks.first(),
+                currentSongbook = selectedSongbook ?: songbook,
                 isLoading = false,
                 sortBy = sortBy,
             )

--- a/shared/src/commonMain/kotlin/com/techbeloved/hymnbook/shared/ui/navigation/NavigationGraph.kt
+++ b/shared/src/commonMain/kotlin/com/techbeloved/hymnbook/shared/ui/navigation/NavigationGraph.kt
@@ -1,11 +1,14 @@
 package com.techbeloved.hymnbook.shared.ui.navigation
 
+import androidx.compose.ui.window.DialogProperties
 import androidx.navigation.NavGraphBuilder
 import androidx.navigation.NavHostController
 import androidx.navigation.compose.composable
+import androidx.navigation.compose.dialog
 import androidx.navigation.toRoute
 import com.techbeloved.hymnbook.shared.model.SongFilter
 import com.techbeloved.hymnbook.shared.ui.detail.SongDetailScreen
+import com.techbeloved.hymnbook.shared.ui.playlist.add.AddEditPlaylistDialog
 import com.techbeloved.hymnbook.shared.ui.search.SearchScreen
 import com.techbeloved.hymnbook.shared.ui.songs.FilteredSongsScreen
 
@@ -39,6 +42,15 @@ internal fun NavGraphBuilder.addNavigationRoutes(navController: NavHostControlle
                         orderByTitle = route.orderByTitle,
                     )
                 )
+            }
+        )
+    }
+
+    dialog<AddEditPlaylistDialog>(dialogProperties = DialogProperties()) {
+        // Set dialog scrim to transparent
+        AddEditPlaylistDialog(
+            onDismiss = {
+                navController.popBackStack()
             }
         )
     }

--- a/shared/src/commonMain/kotlin/com/techbeloved/hymnbook/shared/ui/playlist/PlayListTabScreen.kt
+++ b/shared/src/commonMain/kotlin/com/techbeloved/hymnbook/shared/ui/playlist/PlayListTabScreen.kt
@@ -1,15 +1,385 @@
+@file:OptIn(ExperimentalMaterial3Api::class)
+
 package com.techbeloved.hymnbook.shared.ui.playlist
 
-import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.Canvas
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.BoxWithConstraints
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.twotone.PlaylistAdd
+import androidx.compose.material.icons.twotone.Delete
+import androidx.compose.material.icons.twotone.MoreVert
+import androidx.compose.material3.DropdownMenuItem
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.ExposedDropdownMenuBox
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.IconButtonDefaults
+import androidx.compose.material3.ListItem
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.MenuAnchorType
+import androidx.compose.material3.NavigationBar
+import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.CornerRadius
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.drawText
+import androidx.compose.ui.text.rememberTextMeasurer
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import androidx.lifecycle.viewmodel.compose.viewModel
+import com.techbeloved.hymnbook.shared.model.playlist.PlaylistItem
+import com.techbeloved.hymnbook.shared.ui.AppTopBar
+import com.techbeloved.hymnbook.shared.ui.dialog.AppDialog
+import com.techbeloved.hymnbook.shared.ui.theme.AppTheme
+import com.techbeloved.hymnbook.shared.ui.utils.generateRandomPastelColor
+import kotlinx.collections.immutable.persistentListOf
+import kotlinx.datetime.Instant
+import org.jetbrains.compose.ui.tooling.preview.Preview
 
 @Composable
-internal fun PlayListTabScreen() {
-    Box(Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
-        Text(text = "Playlists")
+internal fun PlayListTabScreen(
+    modifier: Modifier = Modifier,
+    viewModel: PlaylistsViewModel = viewModel(factory = PlaylistsViewModel.Factory),
+    onAddPlaylistClick: () -> Unit,
+) {
+
+    val state by viewModel.state.collectAsStateWithLifecycle()
+    PlaylistsUi(
+        state = state,
+        onAddPlaylistClick = onAddPlaylistClick,
+        onDelete = viewModel::onDeletePlaylist,
+        modifier = modifier,
+    )
+}
+
+@Composable
+private fun PlaylistsUi(
+    state: PlaylistsUiState,
+    onAddPlaylistClick: () -> Unit,
+    onDelete: (PlaylistItem) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    val scrollBehavior = TopAppBarDefaults.pinnedScrollBehavior()
+    Scaffold(
+        topBar = {
+            AppTopBar(
+                showUpButton = false,
+                scrollBehaviour = scrollBehavior,
+                title = "Playlists",
+            )
+        },
+        bottomBar = {
+            // A workaround to apply correct bottom padding to the HomeUi.
+            // The Actual Navigation Bar is provided at the top level scaffold
+            NavigationBar(
+                containerColor = MaterialTheme.colorScheme.surfaceContainer.copy(alpha = 0f),
+            ) { }
+        },
+        modifier = modifier,
+    ) { innerPadding ->
+        if (state.isEmpty) {
+            PlaylistsEmptyUi(
+                modifier = Modifier.padding(paddingValues = innerPadding)
+                    .padding(horizontal = 16.dp)
+                    .fillMaxSize(),
+                onAddPlaylistClick = onAddPlaylistClick
+            )
+        } else {
+            LazyColumn(modifier = Modifier.fillMaxSize(), contentPadding = innerPadding) {
+                items(state.playlists.size) {
+                    PlaylistItem(
+                        item = state.playlists[it],
+                        onDeleteClick = { onDelete(state.playlists[it]) },
+                    )
+                }
+            }
+        }
     }
 }
+
+@Preview
+@Composable
+private fun PlaylistsUiPreview() {
+    val item1 = PlaylistItem(
+        id = 1L,
+        name = "Sunday Morning",
+        description = "Hymns for sunday morning service",
+        created = Instant.DISTANT_PAST,
+        updated = Instant.DISTANT_PAST,
+        imageUrl = null,
+    )
+    val item2 = PlaylistItem(
+        id = 2L,
+        name = "Wednesday evening",
+        description = "Hymns for wednesday evening service",
+        created = Instant.DISTANT_PAST,
+        updated = Instant.DISTANT_PAST,
+        imageUrl = null,
+    )
+    val state =
+        PlaylistsUiState(playlists = kotlinx.collections.immutable.persistentListOf(item1, item2))
+    AppTheme {
+        PlaylistsUi(state = state, onAddPlaylistClick = { }, onDelete = {})
+    }
+}
+
+@Preview
+@Composable
+private fun PlaylistsUiPreviewDark() {
+    val item1 = PlaylistItem(
+        id = 1L,
+        name = "Sunday Morning",
+        description = "Hymns for sunday morning service",
+        created = Instant.DISTANT_PAST,
+        updated = Instant.DISTANT_PAST,
+        imageUrl = null,
+    )
+    val item2 = PlaylistItem(
+        id = 2L,
+        name = "Wednesday evening",
+        description = "Hymns for wednesday evening service",
+        created = Instant.DISTANT_PAST,
+        updated = Instant.DISTANT_PAST,
+        imageUrl = null,
+    )
+    val state =
+        PlaylistsUiState(playlists = kotlinx.collections.immutable.persistentListOf(item1, item2))
+    AppTheme(darkTheme = true) {
+        PlaylistsUi(state = state, onAddPlaylistClick = { }, onDelete = {})
+    }
+}
+
+@Composable
+private fun PlaylistsEmptyUi(
+    onAddPlaylistClick: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Column(
+        modifier = modifier,
+        verticalArrangement = Arrangement.Center,
+        horizontalAlignment = Alignment.CenterHorizontally,
+    ) {
+        IconButton(
+            onClick = onAddPlaylistClick,
+            colors = IconButtonDefaults.filledIconButtonColors(),
+            modifier = Modifier.size(60.dp),
+        ) {
+            Icon(
+                imageVector = Icons.AutoMirrored.TwoTone.PlaylistAdd,
+                contentDescription = "Add Playlist",
+            )
+        }
+
+        Spacer(Modifier.height(16.dp))
+
+        Text(
+            text = "You have not created any playlists yet. Start by clicking the button above.",
+            textAlign = TextAlign.Center,
+            modifier = Modifier.fillMaxWidth(),
+        )
+    }
+}
+
+@Preview
+@Composable
+private fun PlaylistsEmptyUiPreview() {
+    AppTheme {
+        PlaylistsUi(
+            onAddPlaylistClick = {},
+            onDelete = {},
+            state = PlaylistsUiState(playlists = persistentListOf()),
+        )
+    }
+}
+
+@Composable
+private fun PlaylistItem(
+    item: PlaylistItem,
+    onDeleteClick: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    var showDeleteConfirmation by remember { mutableStateOf(false) }
+    ListItem(
+        headlineContent = { Text(text = item.name) },
+        supportingContent = item.description?.let {
+            {
+                Text(
+                    text = it,
+                    maxLines = 2,
+                    overflow = TextOverflow.Ellipsis,
+                )
+            }
+        },
+        modifier = modifier,
+        trailingContent = {
+            PlaylistItemMoreMenu(
+                onDeleteClick = { showDeleteConfirmation = true },
+            )
+        },
+        leadingContent = {
+            PlaylistLetterIcon(playlistName = item.name)
+        },
+    )
+    if (showDeleteConfirmation) {
+        AppDialog(
+            title = "Delete Playlist",
+            content = "Are you sure you want to delete ${item.name}?",
+            positiveText = "Delete",
+            negativeText = "Cancel",
+            onDismiss = { showDeleteConfirmation = false },
+            onConfirm = {
+                onDeleteClick()
+                showDeleteConfirmation = false
+            },
+        )
+    }
+
+}
+
+@Composable
+private fun PlaylistItemMoreMenu(
+    onDeleteClick: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    var isExpanded by remember { mutableStateOf(false) }
+    ExposedDropdownMenuBox(
+        expanded = isExpanded,
+        onExpandedChange = { isExpanded = it },
+        modifier = modifier,
+    ) {
+
+        IconButton(
+            onClick = { },
+            modifier = Modifier.menuAnchor(type = MenuAnchorType.PrimaryNotEditable),
+        ) {
+            Icon(imageVector = Icons.TwoTone.MoreVert, contentDescription = "More options")
+        }
+
+        ExposedDropdownMenu(
+            expanded = isExpanded,
+            onDismissRequest = { isExpanded = false },
+            matchTextFieldWidth = false,
+            shape = MaterialTheme.shapes.medium,
+        ) {
+            DropdownMenuItem(
+                text = { Text(text = "Delete") },
+                onClick = {
+                    onDeleteClick()
+                    isExpanded = false
+                },
+                leadingIcon = {
+                    Icon(
+                        imageVector = Icons.TwoTone.Delete,
+                        contentDescription = "Delete",
+                    )
+                }
+            )
+            // Add Share item
+        }
+
+    }
+}
+
+
+@Preview
+@Composable
+private fun PlaylistItemPreview() {
+    val item = PlaylistItem(
+        id = 1L,
+        name = "My Awesome Playlist",
+        description = "A collection of my favorite hymns",
+        imageUrl = null,
+        created = Instant.DISTANT_PAST,
+        updated = Instant.DISTANT_PAST,
+    )
+    AppTheme {
+        PlaylistItem(item = item, onDeleteClick = {})
+    }
+}
+
+@Preview
+@Composable
+private fun PlaylistLetterIconPreview() {
+    AppTheme {
+        PlaylistLetterIcon(
+            playlistName = "Sunday Hymns",
+        )
+    }
+}
+
+@Composable
+private fun PlaylistLetterIcon(
+    playlistName: String,
+    modifier: Modifier = Modifier,
+    iconSize: Dp = 40.dp, // Default size, same as ListItem leading content size
+    backgroundColor: Color? = null,
+    textColor: Color? = null
+) {
+    val firstLetter = playlistName.firstOrNull()?.uppercaseChar()?.toString() ?: ""
+
+    // Generate a consistent random color based on the playlist name, or use provided
+    val bgColor = remember(playlistName, backgroundColor) {
+        backgroundColor ?: generateRandomPastelColor(seed = playlistName)
+    }
+
+    val determinedTextColor = textColor ?: Color.Black.copy(alpha = .87f)
+
+    val textMeasurer = rememberTextMeasurer()
+
+    BoxWithConstraints(modifier = modifier.size(iconSize), contentAlignment = Alignment.Center) {
+        val canvasSize = constraints.maxWidth // Assuming square icon
+
+        Canvas(modifier = Modifier.size(iconSize)) {
+            // Draw background
+            drawRoundRect(
+                color = bgColor,
+                cornerRadius = CornerRadius(x = 8.dp.toPx(), y = 8.dp.toPx())
+            )
+
+            // Draw letter
+            if (firstLetter.isNotEmpty()) {
+                val style = TextStyle(
+                    color = determinedTextColor,
+                    fontSize = (canvasSize * 0.5f).toSp() // Adjust font size factor as needed
+                    // fontWeight = FontWeight.Bold // Optional: if you want bold
+                )
+                val textLayoutResult = textMeasurer.measure(
+                    text = firstLetter,
+                    style = style
+                )
+                val textWidth = textLayoutResult.size.width
+                val textHeight = textLayoutResult.size.height
+
+                drawText(
+                    textLayoutResult = textLayoutResult,
+                    topLeft = androidx.compose.ui.geometry.Offset(
+                        x = (size.width - textWidth) / 2,
+                        y = (size.height - textHeight) / 2
+                    )
+                )
+            }
+        }
+    }
+}
+

--- a/shared/src/commonMain/kotlin/com/techbeloved/hymnbook/shared/ui/playlist/PlayListTabScreen.kt
+++ b/shared/src/commonMain/kotlin/com/techbeloved/hymnbook/shared/ui/playlist/PlayListTabScreen.kt
@@ -13,13 +13,17 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.twotone.PlaylistAdd
+import androidx.compose.material.icons.twotone.AddCircle
 import androidx.compose.material.icons.twotone.Delete
 import androidx.compose.material.icons.twotone.MoreVert
 import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.ExposedDropdownMenuBox
+import androidx.compose.material3.ExtendedFloatingActionButton
+import androidx.compose.material3.FabPosition
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.IconButtonDefaults
@@ -31,6 +35,7 @@ import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -81,6 +86,9 @@ private fun PlaylistsUi(
     modifier: Modifier = Modifier,
 ) {
     val scrollBehavior = TopAppBarDefaults.pinnedScrollBehavior()
+
+    val listState = rememberLazyListState()
+    val isFabExpanded by remember { derivedStateOf { listState.firstVisibleItemIndex == 0 } }
     Scaffold(
         topBar = {
             AppTopBar(
@@ -96,6 +104,23 @@ private fun PlaylistsUi(
                 containerColor = MaterialTheme.colorScheme.surfaceContainer.copy(alpha = 0f),
             ) { }
         },
+        floatingActionButton = {
+            ExtendedFloatingActionButton(
+                text = {
+                    Text(text = "New", modifier = Modifier.padding(end = 16.dp))
+                },
+                icon = {
+                    Icon(
+                        imageVector = Icons.TwoTone.AddCircle,
+                        contentDescription = "New Playlist"
+                    )
+                },
+                onClick = onAddPlaylistClick,
+                shape = MaterialTheme.shapes.extraLarge,
+                expanded = isFabExpanded,
+            )
+        },
+        floatingActionButtonPosition = FabPosition.End,
         modifier = modifier,
     ) { innerPadding ->
         if (state.isEmpty) {
@@ -103,10 +128,14 @@ private fun PlaylistsUi(
                 modifier = Modifier.padding(paddingValues = innerPadding)
                     .padding(horizontal = 16.dp)
                     .fillMaxSize(),
-                onAddPlaylistClick = onAddPlaylistClick
+                onAddPlaylistClick = onAddPlaylistClick,
             )
         } else {
-            LazyColumn(modifier = Modifier.fillMaxSize(), contentPadding = innerPadding) {
+            LazyColumn(
+                modifier = Modifier.fillMaxSize(),
+                contentPadding = innerPadding,
+                state = listState,
+            ) {
                 items(state.playlists.size) {
                     PlaylistItem(
                         item = state.playlists[it],

--- a/shared/src/commonMain/kotlin/com/techbeloved/hymnbook/shared/ui/playlist/PlaylistsUiState.kt
+++ b/shared/src/commonMain/kotlin/com/techbeloved/hymnbook/shared/ui/playlist/PlaylistsUiState.kt
@@ -1,0 +1,12 @@
+package com.techbeloved.hymnbook.shared.ui.playlist
+
+import com.techbeloved.hymnbook.shared.model.playlist.PlaylistItem
+import kotlinx.collections.immutable.ImmutableList
+import kotlinx.collections.immutable.persistentListOf
+
+internal data class PlaylistsUiState(
+    val isLoading: Boolean = false,
+    val playlists: ImmutableList<PlaylistItem> = persistentListOf(),
+) {
+    val isEmpty = playlists.isEmpty()
+}

--- a/shared/src/commonMain/kotlin/com/techbeloved/hymnbook/shared/ui/playlist/PlaylistsViewModel.kt
+++ b/shared/src/commonMain/kotlin/com/techbeloved/hymnbook/shared/ui/playlist/PlaylistsViewModel.kt
@@ -1,0 +1,46 @@
+package com.techbeloved.hymnbook.shared.ui.playlist
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import androidx.lifecycle.viewmodel.initializer
+import androidx.lifecycle.viewmodel.viewModelFactory
+import com.techbeloved.hymnbook.shared.di.appComponent
+import com.techbeloved.hymnbook.shared.model.playlist.PlaylistItem
+import com.techbeloved.hymnbook.shared.playlist.DeletePlaylistUseCase
+import com.techbeloved.hymnbook.shared.playlist.GetPlaylistsUseCase
+import kotlinx.collections.immutable.toImmutableList
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.stateIn
+import kotlinx.coroutines.launch
+import me.tatarka.inject.annotations.Inject
+
+internal class PlaylistsViewModel @Inject constructor(
+    getPlaylistUseCase: GetPlaylistsUseCase,
+    private val deletePlaylistUseCase: DeletePlaylistUseCase,
+) : ViewModel() {
+
+    val state = getPlaylistUseCase().map { playlists ->
+        PlaylistsUiState(
+            isLoading = false,
+            playlists = playlists.toImmutableList(),
+        )
+    }.stateIn(
+        scope = viewModelScope,
+        started = SharingStarted.WhileSubscribed(5000),
+        initialValue = PlaylistsUiState(isLoading = true),
+    )
+
+    fun onDeletePlaylist(playlistItem: PlaylistItem) {
+        viewModelScope.launch {
+            deletePlaylistUseCase(playlistId = playlistItem.id)
+        }
+    }
+
+    companion object {
+        val Factory = viewModelFactory {
+            initializer { appComponent.playlistsViewModel() }
+        }
+    }
+
+}

--- a/shared/src/commonMain/kotlin/com/techbeloved/hymnbook/shared/ui/playlist/add/AddEditPlaylistDialog.kt
+++ b/shared/src/commonMain/kotlin/com/techbeloved/hymnbook/shared/ui/playlist/add/AddEditPlaylistDialog.kt
@@ -1,0 +1,108 @@
+@file:OptIn(ExperimentalMaterial3Api::class)
+
+package com.techbeloved.hymnbook.shared.ui.playlist.add
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.material3.Button
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.ModalBottomSheet
+import androidx.compose.material3.OutlinedButton
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextField
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.unit.dp
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import androidx.lifecycle.viewmodel.compose.viewModel
+import kotlinx.coroutines.Dispatchers
+import kotlinx.serialization.Serializable
+
+@Serializable
+internal data class AddEditPlaylistDialog(
+    val playlistId: Long?,
+)
+
+@Composable
+internal fun AddEditPlaylistDialog(
+    onDismiss: (savedPlaylistId: Long?) -> Unit,
+    modifier: Modifier = Modifier,
+    viewModel: AddEditPlaylistViewModel = viewModel(factory = AddEditPlaylistViewModel.Factory),
+) {
+
+    val state by viewModel.state.collectAsStateWithLifecycle(context = Dispatchers.Main.immediate)
+
+    LaunchedEffect(state.savedPlaylistId) {
+        if (state.savedPlaylistId != null) {
+            onDismiss(state.savedPlaylistId)
+        }
+    }
+
+    ModalBottomSheet(
+        onDismissRequest = { onDismiss(null) },
+        modifier = modifier,
+        scrimColor = Color.Transparent,
+    ) {
+        Column(
+            horizontalAlignment = Alignment.CenterHorizontally,
+            modifier = Modifier.fillMaxWidth()
+                .padding(16.dp),
+        ) {
+            Text(
+                text = "New Playlist",
+                style = MaterialTheme.typography.titleMedium,
+                modifier = Modifier.align(Alignment.CenterHorizontally),
+            )
+            Spacer(Modifier.height(16.dp))
+            TextField(
+                value = state.name,
+                onValueChange = viewModel::onNameChanged,
+                label = { Text("Title") },
+                modifier = Modifier.align(Alignment.CenterHorizontally)
+                    .fillMaxWidth(),
+                singleLine = true,
+            )
+            Spacer(Modifier.height(16.dp))
+            TextField(
+                value = state.description,
+                onValueChange = viewModel::onDescriptionChanged,
+                label = { Text("Description") },
+                modifier = Modifier.align(Alignment.CenterHorizontally)
+                    .fillMaxWidth(),
+                singleLine = true,
+            )
+            Spacer(Modifier.height(16.dp))
+            Row(
+                horizontalArrangement = Arrangement.Center,
+                modifier = Modifier.fillMaxWidth(),
+
+                ) {
+                OutlinedButton(onClick = { onDismiss(null) }) {
+                    Text("Cancel")
+                }
+
+                Spacer(Modifier.width(16.dp))
+
+                Button(
+                    onClick = {
+                        viewModel.onSavePlaylist()
+                    },
+                    enabled = state.isModified && !state.isLoading,
+                ) {
+                    Text("Create")
+                }
+            }
+        }
+    }
+}

--- a/shared/src/commonMain/kotlin/com/techbeloved/hymnbook/shared/ui/playlist/add/AddEditPlaylistState.kt
+++ b/shared/src/commonMain/kotlin/com/techbeloved/hymnbook/shared/ui/playlist/add/AddEditPlaylistState.kt
@@ -1,0 +1,18 @@
+package com.techbeloved.hymnbook.shared.ui.playlist.add
+
+import com.techbeloved.hymnbook.shared.model.playlist.PlaylistItem
+
+internal data class AddEditPlaylistState(
+    val oldItem: PlaylistItem? = null,
+    val name: String = "",
+    val description: String = "",
+    val imageUrl: String? = null,
+    val isNewPlaylist: Boolean = oldItem == null,
+    val isLoading: Boolean = false,
+    val savedPlaylistId: Long? = null,
+) {
+    val isModified: Boolean = (name.isNotBlank()) && (oldItem?.name != name
+            || oldItem.description != description
+            || oldItem.imageUrl != imageUrl)
+
+}

--- a/shared/src/commonMain/kotlin/com/techbeloved/hymnbook/shared/ui/playlist/add/AddEditPlaylistViewModel.kt
+++ b/shared/src/commonMain/kotlin/com/techbeloved/hymnbook/shared/ui/playlist/add/AddEditPlaylistViewModel.kt
@@ -1,0 +1,138 @@
+package com.techbeloved.hymnbook.shared.ui.playlist.add
+
+import androidx.lifecycle.SavedStateHandle
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.createSavedStateHandle
+import androidx.lifecycle.viewModelScope
+import androidx.lifecycle.viewmodel.initializer
+import androidx.lifecycle.viewmodel.viewModelFactory
+import androidx.navigation.toRoute
+import com.techbeloved.hymnbook.shared.di.appComponent
+import com.techbeloved.hymnbook.shared.playlist.CreatePlaylistUseCase
+import com.techbeloved.hymnbook.shared.playlist.GetPlaylistByIdUseCase
+import com.techbeloved.hymnbook.shared.playlist.UpdatePlaylistUseCase
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.flow.stateIn
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+import me.tatarka.inject.annotations.Assisted
+import me.tatarka.inject.annotations.Inject
+
+internal class AddEditPlaylistViewModel @Inject constructor(
+    private val createPlaylistUseCase: CreatePlaylistUseCase,
+    private val updatePlaylistUseCase: UpdatePlaylistUseCase,
+    private val getPlaylistByIdUseCase: GetPlaylistByIdUseCase,
+    @Assisted private val savedStateHandle: SavedStateHandle,
+) : ViewModel() {
+
+    private val args = savedStateHandle.toRoute<AddEditPlaylistDialog>()
+    private val playlistName = savedStateHandle.getStateFlow<String?>("playlistName", null)
+    private val playlistDescription =
+        savedStateHandle.getStateFlow<String?>("playlistDescription", null)
+
+    private val playlistImageUrl = savedStateHandle.getStateFlow<String?>("playlistImageUrl", null)
+
+    private val inProgress = MutableStateFlow(false)
+    private val savedPlaylistId = MutableStateFlow<Long?>(null)
+
+    private val editing = combine(
+        playlistName,
+        playlistDescription,
+        playlistImageUrl
+    ) { name, description, imageUrl ->
+        Editing(
+            name = name ?: "",
+            description = description ?: "",
+            imageUrl = imageUrl,
+        )
+    }
+
+    private val oldPlaylist = flow {
+        val playlist =
+            if (args.playlistId != null) getPlaylistByIdUseCase(args.playlistId) else null
+        emit(playlist)
+    }
+
+    val state = combine(
+        oldPlaylist,
+        editing,
+        inProgress,
+        savedPlaylistId,
+    ) { oldPlaylist, editing, inProgress, playlistSaved ->
+        // Prefer the user changed values. Except it is empty, in which case use the old value
+        AddEditPlaylistState(
+            oldItem = oldPlaylist,
+            name = editing.name.ifBlank { oldPlaylist?.name ?: "" },
+            description = editing.description.ifBlank { oldPlaylist?.description ?: "" },
+            imageUrl = editing.imageUrl ?: oldPlaylist?.imageUrl,
+            isLoading = inProgress,
+            savedPlaylistId = playlistSaved,
+        )
+    }.stateIn(
+        scope = viewModelScope,
+        started = SharingStarted.WhileSubscribed(stopTimeoutMillis = 5_000),
+        initialValue = AddEditPlaylistState(isNewPlaylist = true),
+    )
+
+    fun onNameChanged(name: String) {
+        if (name.length < NAME_MAX_LENGTH) {
+            savedStateHandle["playlistName"] = name
+        }
+    }
+
+    fun onDescriptionChanged(description: String) {
+        if (description.length < DESCRIPTION_MAX_LENGTH) {
+            savedStateHandle["playlistDescription"] = description
+        }
+    }
+
+    fun onImageUrlChanged(imageUrl: String?) {
+        savedStateHandle["playlistImageUrl"] = imageUrl
+    }
+
+    fun onSavePlaylist() {
+        inProgress.update { true }
+        viewModelScope.launch {
+            val currentState = state.value
+            val playlistId = if (args.playlistId != null) {
+                updatePlaylistUseCase(
+                    playlistId = args.playlistId,
+                    name = currentState.name,
+                    description = currentState.description.ifBlank { null },
+                    imageUrl = currentState.imageUrl,
+                )
+            } else {
+                createPlaylistUseCase(
+                    name = currentState.name,
+                    description = currentState.description.ifBlank { null },
+                    imageUrl = currentState.imageUrl,
+                )
+            }
+            inProgress.update { false }
+            savedPlaylistId.update { playlistId }
+        }
+    }
+
+    data class Editing(
+        val name: String,
+        val description: String,
+        val imageUrl: String?,
+    )
+
+    @Inject
+    class Factory(val create: (SavedStateHandle) -> AddEditPlaylistViewModel)
+
+    companion object Companion {
+        val Factory = viewModelFactory {
+            initializer<AddEditPlaylistViewModel> {
+                appComponent.addNewPlaylistViewModelFactory().create(createSavedStateHandle())
+            }
+        }
+
+        const val DESCRIPTION_MAX_LENGTH = 200
+        const val NAME_MAX_LENGTH = 50
+    }
+}

--- a/shared/src/commonMain/kotlin/com/techbeloved/hymnbook/shared/ui/utils/RandomColorUtils.kt
+++ b/shared/src/commonMain/kotlin/com/techbeloved/hymnbook/shared/ui/utils/RandomColorUtils.kt
@@ -1,0 +1,14 @@
+package com.techbeloved.hymnbook.shared.ui.utils
+
+
+import androidx.compose.ui.graphics.Color
+import kotlin.random.Random
+
+internal fun generateRandomPastelColor(seed: String? = null): Color {
+    val random = if (seed != null) Random(seed.hashCode()) else Random.Default
+    return Color(
+        red = (random.nextInt(until = 128) + 127) / 255f,   // Bias towards lighter tones
+        green = (random.nextInt(until = 128) + 127) / 255f, // Bias towards lighter tones
+        blue = (random.nextInt(until = 128) + 127) / 255f,  // Bias towards lighter tones
+    )
+}

--- a/shared/src/commonMain/sqldelight/com/techbeloved/hymnbook/PlaylistEntity.sq
+++ b/shared/src/commonMain/sqldelight/com/techbeloved/hymnbook/PlaylistEntity.sq
@@ -1,0 +1,28 @@
+import kotlinx.datetime.Instant;
+CREATE TABLE IF NOT EXISTS PlaylistEntity (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    name TEXT NOT NULL,
+    description TEXT,
+    image_url TEXT,
+    created INTEGER AS Instant NOT NULL,
+    modified INTEGER AS Instant NOT NULL
+);
+
+insert:
+INSERT OR IGNORE INTO PlaylistEntity(id, name, description, image_url, created, modified)
+VALUES (?,?,?,?,?,?);
+
+update:
+UPDATE PlaylistEntity
+SET name = :name,
+    description = :description,
+    image_url = :imageUrl,
+    modified = :modified;
+
+getAll:
+SELECT * FROM PlaylistEntity
+ORDER BY created;
+
+delete:
+DELETE FROM PlaylistEntity
+WHERE id = :playlistId;

--- a/shared/src/commonMain/sqldelight/com/techbeloved/hymnbook/PlaylistEntity.sq
+++ b/shared/src/commonMain/sqldelight/com/techbeloved/hymnbook/PlaylistEntity.sq
@@ -17,11 +17,19 @@ UPDATE PlaylistEntity
 SET name = :name,
     description = :description,
     image_url = :imageUrl,
-    modified = :modified;
+    modified = :modified
+WHERE id = :playlistId;
+
+lastInsertRowId:
+SELECT last_insert_rowid();
 
 getAll:
 SELECT * FROM PlaylistEntity
 ORDER BY created;
+
+getById:
+SELECT * FROM PlaylistEntity
+WHERE id = :playlistId;
 
 delete:
 DELETE FROM PlaylistEntity

--- a/shared/src/commonMain/sqldelight/com/techbeloved/hymnbook/PlaylistSongs.sq
+++ b/shared/src/commonMain/sqldelight/com/techbeloved/hymnbook/PlaylistSongs.sq
@@ -1,0 +1,17 @@
+CREATE TABLE IF NOT EXISTS PlaylistSongs (
+    playlist_id INTEGER,
+    song_id INTEGER,
+    PRIMARY KEY (playlist_id, song_id),
+    FOREIGN KEY (song_id) REFERENCES SongEntity(id) ON DELETE CASCADE,
+    FOREIGN KEY (playlist_id) REFERENCES PlaylistEntity(id) ON DELETE CASCADE
+);
+
+insert:
+INSERT OR IGNORE INTO PlaylistSongs(playlist_id, song_id)
+VALUES (?,?);
+
+getSongsInPlaylist:
+SELECT sd.id, sd.title, sd.alternate_title FROM SongDetail AS sd
+JOIN PlaylistSongs AS ps
+ON ps.song_id = sd.id
+WHERE ps.playlist_id = :playlistId;

--- a/shared/src/commonMain/sqldelight/com/techbeloved/hymnbook/SongEntity.sq
+++ b/shared/src/commonMain/sqldelight/com/techbeloved/hymnbook/SongEntity.sq
@@ -11,6 +11,7 @@ CREATE TABLE IF NOT EXISTS SongEntity (
     comments TEXT,
     search_title TEXT NOT NULL COLLATE NOCASE,
     search_lyrics TEXT NOT NULL COLLATE NOCASE,
+    search_songbook TEXT NOT NULL COLLATE NOCASE,
     created INTEGER AS Instant NOT NULL,
     modified INTEGER AS Instant NOT NULL
 );
@@ -46,10 +47,25 @@ CREATE TRIGGER trigger_songs_fts_after_update AFTER UPDATE ON SongEntity BEGIN
   INSERT INTO songs_fts(rowid, search_title, search_lyrics) VALUES(new.id, new.search_title, new.search_lyrics);
 END;
 
+-- Full Text Search songbook entry
+CREATE VIRTUAL TABLE songbook_fts USING fts5(search_songbook, content=SongEntity, content_rowid=id, tokenize=porter);
+
+CREATE TRIGGER trigger_songbook_fts_after_insert AFTER INSERT ON SongEntity BEGIN
+  INSERT INTO songbook_fts(rowid, search_songbook) VALUES(new.id, new.search_songbook);
+END;
+
+CREATE TRIGGER trigger_songbook_fts_after_delete AFTER DELETE ON SongEntity BEGIN
+  INSERT INTO songbook_fts(songbook_fts, rowid, search_songbook) VALUES('delete', old.id, old.search_songbook);
+END;
+
+CREATE TRIGGER trigger_songbook_fts_after_update AFTER UPDATE ON SongEntity BEGIN
+  INSERT INTO songbook_fts(songbook_fts, rowid, search_songbook) VALUES('delete', old.id, old.search_songbook);
+  INSERT INTO songbook_fts(rowid, search_songbook) VALUES(new.id, new.search_songbook);
+END;
 
 insert:
-INSERT INTO SongEntity(id, title, alternate_title, lyrics, verse_order, copyright, comments, search_title, search_lyrics, created, modified)
-VALUES(?, ?,?,?,?,?,?,?,?,?,?);
+INSERT INTO SongEntity(id, title, alternate_title, lyrics, verse_order, copyright, comments, search_title, search_lyrics, search_songbook, created, modified)
+VALUES(?, ?,?,?,?,?,?,?,?,?,?, ?);
 
 lastInsertRowId:
 SELECT last_insert_rowid();
@@ -64,6 +80,7 @@ SET title = :title,
     comments = :comments,
     search_title = :search_title,
     search_lyrics = :search_lyrics,
+    search_songbook = :search_songbook,
     modified = :modified
 WHERE id = :id;
 
@@ -79,7 +96,7 @@ ON S.id = B.song_id
 WHERE S.title = ? AND B.songbook = ?;
 
 -- write a sqldelight query to get a list of songs given the following filter parameters
-   -- list of topics and list of songbooks
+-- list of topics and list of songbooks
 
 filterSongsByTopicsAndSongbooks:
 SELECT DISTINCT sd.id, sd.title, sd.alternate_title, sbs.songbook, sbs.entry
@@ -133,6 +150,14 @@ ON S.id = B.song_id
 JOIN songs_fts ON S.id=songs_fts.rowid
 WHERE songs_fts MATCH :search
 ORDER BY bm25(songs_fts, 10.0);
+
+searchSongbookEntry:
+SELECT S.id, S.title, S.alternate_title, B.songbook, B.entry FROM SongEntity AS S
+LEFT JOIN SongbookSongs AS B
+ON S.id = B.song_id
+JOIN songbook_fts ON S.id=songbook_fts.rowid
+WHERE songbook_fts MATCH :search
+ORDER BY bm25(songbook_fts, 10.0);
 
 
 deleteAll:


### PR DESCRIPTION
feat: Implement Playlist feature and enhance song search

This commit introduces the initial implementation of the Playlist feature and improves song search functionality.

Refactor: Implement Add/Edit Playlist functionality

**Playlist Feature:**
- **Database:**
    - Added `PlaylistEntity.sq` for storing playlist metadata (name, description, image, created/modified timestamps).
    - Added `PlaylistSongs.sq` for linking songs to playlists (many-to-many relationship).
    - Updated database schema in `Injector.kt` to include adapters for `PlaylistEntity`.
- **Use Cases:**
    - `GetPlaylistsUseCase`: Retrieves a flow of all playlists.
    - `DeletePlaylistUseCase`: Deletes a playlist by its ID.
    - `GetSongsInPlaylistUseCase`: Fetches all songs belonging to a specific playlist.
- **UI & ViewModel:**
    - Created `PlaylistsViewModel` to manage playlist data and interactions.
    - Introduced `PlayListTabScreen` to display the list of playlists.
    - Implemented `PlaylistsUiState` to represent the state of the playlist screen.
    - Added UI components for displaying playlist items (`PlaylistItem`), including a letter-based icon (`PlaylistLetterIcon`) and a context menu for actions like deletion.
    - Included an empty state UI (`PlaylistsEmptyUi`) for when no playlists exist.
    - Added an `AppDialog` composable for confirmation dialogs (e.g., delete playlist).
    - Integrated `PlayListTabScreen` into the `HomeGraph`.
- **Models:**
    - `PlaylistItem`: Data class representing a playlist.
    - `SongInPlaylist`: Data class for songs listed within a playlist.

**Song Search Enhancement:**
- `SearchSongsUseCase` now checks if the search query consists only of digits.
    - If it's all digits, it uses `searchSongbookEntry` to search within songbook numbers.
    - Otherwise, it performs a general search using `searchSongs`.
- Added `search_songbook` field to `SongEntity.sq` and its FTS table `songbook_fts` to enable searching by songbook entry numbers.
- Updated `SaveOpenLyricsUseCase` to populate the new `search_songbook` field.

**Other Changes:**
- **Dependencies:**
    - Added `sqldelight-coroutines-extensions`.
    - Added `jetbrains-runtime-compose` for `collectAsStateWithLifecycle`.
- **Utilities:**
    - Created `generateRandomPastelColor` utility function for playlist icons.
- **Build:**
    - Minor update to iOS scheme file.
- **Refactor:**
    - Made `dateColumnAdapter` in `ColumnAdapters.kt` a `fun` instead of `inline fun`.
    - Improved `HomeScreenModel` to handle cases where `selectedSongbook` might be null initially.