### PR TITLE
106-add-song-to-playlist

### DIFF
--- a/shared/src/commonMain/kotlin/com/techbeloved/hymnbook/shared/App.kt
+++ b/shared/src/commonMain/kotlin/com/techbeloved/hymnbook/shared/App.kt
@@ -6,10 +6,14 @@ import androidx.compose.animation.fadeOut
 import androidx.compose.animation.slideInVertically
 import androidx.compose.animation.slideOutVertically
 import androidx.compose.material3.Scaffold
+import androidx.compose.material3.SnackbarHost
+import androidx.compose.material3.SnackbarHostState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Modifier
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.currentBackStackEntryAsState
@@ -22,6 +26,7 @@ import com.techbeloved.hymnbook.shared.ui.home.navigationItems
 import com.techbeloved.hymnbook.shared.ui.navigation.LocalNavController
 import com.techbeloved.hymnbook.shared.ui.navigation.addNavigationRoutes
 import com.techbeloved.hymnbook.shared.ui.theme.AppTheme
+import kotlinx.coroutines.launch
 
 @Composable
 public fun App() {
@@ -29,6 +34,8 @@ public fun App() {
         val navController = rememberNavController()
         val navBackStackEntry by navController.currentBackStackEntryAsState()
         val isBottomNavVisible by derivedStateOf { navBackStackEntry?.destination?.isATopLevelDestination() == true }
+        val snackbarHostState = remember { SnackbarHostState() }
+        val scope = rememberCoroutineScope()
         Scaffold(
             bottomBar = {
                 AnimatedVisibility(
@@ -41,7 +48,8 @@ public fun App() {
                         navController = navController,
                     )
                 }
-            }
+            },
+            snackbarHost = { SnackbarHost(snackbarHostState) },
         ) {
             CompositionLocalProvider(LocalNavController provides navController) {
                 NavHost(
@@ -51,7 +59,9 @@ public fun App() {
                 ) {
                     addHomeRoutes(navController)
 
-                    addNavigationRoutes(navController)
+                    addNavigationRoutes(navController) { snackMessage ->
+                        scope.launch { snackbarHostState.showSnackbar(snackMessage) }
+                    }
                 }
             }
         }

--- a/shared/src/commonMain/kotlin/com/techbeloved/hymnbook/shared/App.kt
+++ b/shared/src/commonMain/kotlin/com/techbeloved/hymnbook/shared/App.kt
@@ -19,7 +19,7 @@ import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.currentBackStackEntryAsState
 import androidx.navigation.compose.rememberNavController
 import com.techbeloved.hymnbook.shared.ui.appbar.BottomNavigationBar
-import com.techbeloved.hymnbook.shared.ui.home.TopLevelRoute
+import com.techbeloved.hymnbook.shared.ui.home.TopLevelDestination
 import com.techbeloved.hymnbook.shared.ui.home.addHomeRoutes
 import com.techbeloved.hymnbook.shared.ui.home.isATopLevelDestination
 import com.techbeloved.hymnbook.shared.ui.home.navigationItems
@@ -54,7 +54,7 @@ public fun App() {
             CompositionLocalProvider(LocalNavController provides navController) {
                 NavHost(
                     navController = navController,
-                    startDestination = TopLevelRoute,
+                    startDestination = TopLevelDestination.Home,
                     modifier = Modifier,
                 ) {
                     addHomeRoutes(navController)

--- a/shared/src/commonMain/kotlin/com/techbeloved/hymnbook/shared/di/AppComponent.kt
+++ b/shared/src/commonMain/kotlin/com/techbeloved/hymnbook/shared/di/AppComponent.kt
@@ -17,6 +17,7 @@ import com.techbeloved.hymnbook.shared.ui.detail.SongDetailScreenModel
 import com.techbeloved.hymnbook.shared.ui.home.HomeScreenModel
 import com.techbeloved.hymnbook.shared.ui.playlist.PlaylistsViewModel
 import com.techbeloved.hymnbook.shared.ui.playlist.add.AddEditPlaylistViewModel
+import com.techbeloved.hymnbook.shared.ui.playlist.select.AddSongToPlaylistViewModel
 import com.techbeloved.hymnbook.shared.ui.search.SearchScreenModel
 import com.techbeloved.hymnbook.shared.ui.songs.FilteredSongsViewModel
 import com.techbeloved.hymnbook.shared.ui.topics.TopicsViewModel
@@ -68,6 +69,7 @@ internal interface AppComponent {
     fun provideInstantProvider(instantProvider: DefaultInstantProvider): InstantProvider =
         instantProvider
     fun addNewPlaylistViewModelFactory(): AddEditPlaylistViewModel.Factory
+    fun addSongToPlaylistViewModelFactory(): AddSongToPlaylistViewModel.Factory
 
     companion object
 }

--- a/shared/src/commonMain/kotlin/com/techbeloved/hymnbook/shared/model/SongFilter.kt
+++ b/shared/src/commonMain/kotlin/com/techbeloved/hymnbook/shared/model/SongFilter.kt
@@ -6,11 +6,13 @@ import kotlinx.serialization.Serializable
 internal data class SongFilter(
     val topics: List<String>,
     val songbooks: List<String>,
+    val playlistIds: List<Long>,
     val orderByTitle: Boolean,
 ) {
     val byTopicsAndSongbooks: Boolean = topics.isNotEmpty() && songbooks.isNotEmpty()
     val byTopicsOnly: Boolean = topics.isNotEmpty() && songbooks.isEmpty()
     val bySongbooks: Boolean = topics.isEmpty() && songbooks.isNotEmpty()
+    val byPlaylists: Boolean = playlistIds.isNotEmpty()
     val none: Boolean = topics.isEmpty() && songbooks.isEmpty()
 
     companion object {
@@ -18,12 +20,14 @@ internal data class SongFilter(
         val NONE = SongFilter(
             topics = emptyList(),
             songbooks = emptyList(),
+            playlistIds = emptyList(),
             orderByTitle = false,
         )
 
         fun songbookFilter(songbook: String, sortByTitle: Boolean = false): SongFilter = SongFilter(
             topics = emptyList(),
             songbooks = listOf(songbook),
+            playlistIds = emptyList(),
             orderByTitle = sortByTitle,
         )
     }

--- a/shared/src/commonMain/kotlin/com/techbeloved/hymnbook/shared/model/playlist/PlaylistItem.kt
+++ b/shared/src/commonMain/kotlin/com/techbeloved/hymnbook/shared/model/playlist/PlaylistItem.kt
@@ -6,6 +6,7 @@ internal data class PlaylistItem(
     val id: Long,
     val name: String,
     val description: String?,
+    val songCount: Long,
     val imageUrl: String?,
     val created: Instant,
     val updated: Instant,

--- a/shared/src/commonMain/kotlin/com/techbeloved/hymnbook/shared/playlist/AddSongToPlaylistUseCase.kt
+++ b/shared/src/commonMain/kotlin/com/techbeloved/hymnbook/shared/playlist/AddSongToPlaylistUseCase.kt
@@ -1,0 +1,16 @@
+package com.techbeloved.hymnbook.shared.playlist
+
+import com.techbeloved.hymnbook.Database
+import kotlinx.coroutines.NonCancellable
+import kotlinx.coroutines.withContext
+import me.tatarka.inject.annotations.Inject
+
+internal class AddSongToPlaylistUseCase @Inject constructor(
+    private val database: Database,
+) {
+
+    suspend operator fun invoke(songId: Long, playlistId: Long) = withContext(NonCancellable) {
+        database.playlistSongsQueries.insert(playlist_id = playlistId, song_id = songId).await()
+    }
+
+}

--- a/shared/src/commonMain/kotlin/com/techbeloved/hymnbook/shared/playlist/GetPlaylistByIdUseCase.kt
+++ b/shared/src/commonMain/kotlin/com/techbeloved/hymnbook/shared/playlist/GetPlaylistByIdUseCase.kt
@@ -12,7 +12,9 @@ internal class GetPlaylistByIdUseCase @Inject constructor(
 ) {
     suspend operator fun invoke(playlistId: Long): PlaylistItem =
         withContext(dispatchersProvider.io()) {
-            database.playlistEntityQueries.getById(playlistId) { id, name, description, imageUrl, created, modified ->
+            database.playlistEntityQueries.getById(
+                playlistId = playlistId,
+            ) { id, name, description, imageUrl, created, modified, songCount ->
                 PlaylistItem(
                     id = id,
                     name = name,
@@ -20,6 +22,7 @@ internal class GetPlaylistByIdUseCase @Inject constructor(
                     imageUrl = imageUrl,
                     created = created,
                     updated = modified,
+                    songCount = songCount,
                 )
 
             }.executeAsOne()

--- a/shared/src/commonMain/kotlin/com/techbeloved/hymnbook/shared/playlist/GetPlaylistsUseCase.kt
+++ b/shared/src/commonMain/kotlin/com/techbeloved/hymnbook/shared/playlist/GetPlaylistsUseCase.kt
@@ -13,7 +13,7 @@ internal class GetPlaylistsUseCase @Inject constructor(
     private val dispatchersProvider: DispatchersProvider,
 ) {
     operator fun invoke(): Flow<List<PlaylistItem>> =
-        database.playlistEntityQueries.getAll { id, name, description, imageUrl, created, updated ->
+        database.playlistEntityQueries.getAll { id, name, description, imageUrl, created, updated, songCount ->
             PlaylistItem(
                 id = id,
                 name = name,
@@ -21,6 +21,7 @@ internal class GetPlaylistsUseCase @Inject constructor(
                 imageUrl = imageUrl,
                 created = created,
                 updated = updated,
+                songCount = songCount,
             )
         }.asFlow().mapToList(context = dispatchersProvider.io())
 }

--- a/shared/src/commonMain/kotlin/com/techbeloved/hymnbook/shared/titles/GetFilteredSongTitlesUseCase.kt
+++ b/shared/src/commonMain/kotlin/com/techbeloved/hymnbook/shared/titles/GetFilteredSongTitlesUseCase.kt
@@ -37,6 +37,12 @@ internal class GetFilteredSongTitlesUseCase @Inject constructor(
                     mapper = ::SongTitle,
                 )
             }
+            songFilter.byPlaylists -> {
+                database.songEntityQueries.filterSongsByPlaylists(
+                    playlistIds = songFilter.playlistIds,
+                    mapper = ::SongTitle,
+                )
+            }
 
             else -> {
                 database.songEntityQueries.filterSongs(

--- a/shared/src/commonMain/kotlin/com/techbeloved/hymnbook/shared/ui/detail/SongDetailScreen.kt
+++ b/shared/src/commonMain/kotlin/com/techbeloved/hymnbook/shared/ui/detail/SongDetailScreen.kt
@@ -61,9 +61,15 @@ internal data class SongDetailScreen(
     val initialSongId: Long,
     val topics: List<String>,
     val songbooks: List<String>,
+    val playlistIds: List<Long>,
     val orderByTitle: Boolean,
 ) {
-    val songFilter get() = SongFilter(topics, songbooks, orderByTitle)
+    val songFilter get() = SongFilter(
+        topics = topics,
+        songbooks = songbooks,
+        playlistIds = playlistIds,
+        orderByTitle = orderByTitle,
+    )
 }
 
 @Composable

--- a/shared/src/commonMain/kotlin/com/techbeloved/hymnbook/shared/ui/home/HomeGraph.kt
+++ b/shared/src/commonMain/kotlin/com/techbeloved/hymnbook/shared/ui/home/HomeGraph.kt
@@ -13,6 +13,7 @@ import androidx.navigation.compose.composable
 import androidx.navigation.navigation
 import com.techbeloved.hymnbook.TopicEntity
 import com.techbeloved.hymnbook.shared.model.SongFilter
+import com.techbeloved.hymnbook.shared.model.playlist.PlaylistItem
 import com.techbeloved.hymnbook.shared.ui.appbar.HomeNavItem
 import com.techbeloved.hymnbook.shared.ui.detail.SongDetailScreen
 import com.techbeloved.hymnbook.shared.ui.discover.DiscoverTabScreen
@@ -78,6 +79,7 @@ internal fun NavGraphBuilder.addHomeRoutes(
                         songbooks = song.songbook?.let { listOf(it) }
                             ?: SongFilter.NONE.songbooks,
                         orderByTitle = SongFilter.NONE.orderByTitle,
+                        playlistIds = SongFilter.NONE.playlistIds,
                     )
                 )
             },
@@ -86,21 +88,19 @@ internal fun NavGraphBuilder.addHomeRoutes(
 
     composable<TopLevelDestination.Discover> {
         DiscoverTabScreen { topic ->
-            val songFilter = topic.toSongFilter()
-            navController.navigate(
-                FilteredSongsScreen(
-                    topics = songFilter.topics,
-                    songbooks = songFilter.songbooks,
-                    orderByTitle = songFilter.orderByTitle,
-                )
-            )
+            navController.navigate(topic.toSongsDestination())
         }
     }
 
     composable<TopLevelDestination.Playlists> {
-        PlayListTabScreen {
-            navController.navigate(AddEditPlaylistDialog(playlistId = null, songId = null))
-        }
+        PlayListTabScreen(
+            onAddPlaylistClick = {
+                navController.navigate(AddEditPlaylistDialog(playlistId = null, songId = null))
+            },
+            onOpenPlaylistDetail = { item ->
+                navController.navigate(item.toSongsDestination())
+            },
+        )
     }
 
     composable<TopLevelDestination.More> {
@@ -108,13 +108,22 @@ internal fun NavGraphBuilder.addHomeRoutes(
     }
 }
 
-private fun TopicEntity.toSongFilter(): SongFilter {
-    return SongFilter(
-        topics = listOf(name),
-        songbooks = emptyList(),
-        orderByTitle = false,
-    )
-}
+private fun TopicEntity.toSongsDestination() = FilteredSongsScreen(
+    topics = listOf(name),
+    songbooks = SongFilter.NONE.songbooks,
+    orderByTitle = SongFilter.NONE.orderByTitle,
+    playlistIds = SongFilter.NONE.playlistIds,
+    title = name,
+)
+
+// This is temporary until the playlist detail screen is implemented
+private fun PlaylistItem.toSongsDestination() = FilteredSongsScreen(
+    topics = SongFilter.NONE.topics,
+    songbooks = SongFilter.NONE.songbooks,
+    orderByTitle = SongFilter.NONE.orderByTitle,
+    playlistIds = listOf(id),
+    title = name,
+)
 
 internal fun NavDestination.isATopLevelDestination(): Boolean =
     hasRoute<TopLevelDestination.Home>() ||

--- a/shared/src/commonMain/kotlin/com/techbeloved/hymnbook/shared/ui/home/HomeGraph.kt
+++ b/shared/src/commonMain/kotlin/com/techbeloved/hymnbook/shared/ui/home/HomeGraph.kt
@@ -10,7 +10,6 @@ import androidx.navigation.NavDestination.Companion.hasRoute
 import androidx.navigation.NavGraphBuilder
 import androidx.navigation.NavHostController
 import androidx.navigation.compose.composable
-import androidx.navigation.navigation
 import com.techbeloved.hymnbook.TopicEntity
 import com.techbeloved.hymnbook.shared.model.SongFilter
 import com.techbeloved.hymnbook.shared.model.playlist.PlaylistItem
@@ -49,8 +48,6 @@ internal val navigationItems = persistentListOf(
 )
 
 @Serializable
-internal data object TopLevelRoute
-
 internal sealed interface TopLevelDestination {
     @Serializable
     data object Home : TopLevelDestination
@@ -66,8 +63,8 @@ internal sealed interface TopLevelDestination {
 }
 
 internal fun NavGraphBuilder.addHomeRoutes(
-    navController: NavHostController
-) = navigation<TopLevelRoute>(startDestination = TopLevelDestination.Home) {
+    navController: NavHostController,
+) {
     composable<TopLevelDestination.Home> {
         HomeTabScreen(
             onOpenSearch = { navController.navigate(SearchScreen) },

--- a/shared/src/commonMain/kotlin/com/techbeloved/hymnbook/shared/ui/home/HomeGraph.kt
+++ b/shared/src/commonMain/kotlin/com/techbeloved/hymnbook/shared/ui/home/HomeGraph.kt
@@ -64,48 +64,49 @@ internal sealed interface TopLevelDestination {
     data object More : TopLevelDestination
 }
 
-internal fun NavGraphBuilder.addHomeRoutes(navController: NavHostController) =
-    navigation<TopLevelRoute>(startDestination = TopLevelDestination.Home) {
-        composable<TopLevelDestination.Home> {
-            HomeTabScreen(
-                onOpenSearch = { navController.navigate(SearchScreen) },
-                onSongItemClicked = { song ->
-                    navController.navigate(
-                        SongDetailScreen(
-                            initialSongId = song.id,
-                            topics = SongFilter.NONE.topics,
-                            songbooks = song.songbook?.let { listOf(it) }
-                                ?: SongFilter.NONE.songbooks,
-                            orderByTitle = SongFilter.NONE.orderByTitle,
-                        )
-                    )
-                },
-            )
-        }
-
-        composable<TopLevelDestination.Discover> {
-            DiscoverTabScreen { topic ->
-                val songFilter = topic.toSongFilter()
+internal fun NavGraphBuilder.addHomeRoutes(
+    navController: NavHostController
+) = navigation<TopLevelRoute>(startDestination = TopLevelDestination.Home) {
+    composable<TopLevelDestination.Home> {
+        HomeTabScreen(
+            onOpenSearch = { navController.navigate(SearchScreen) },
+            onSongItemClicked = { song ->
                 navController.navigate(
-                    FilteredSongsScreen(
-                        topics = songFilter.topics,
-                        songbooks = songFilter.songbooks,
-                        orderByTitle = songFilter.orderByTitle,
+                    SongDetailScreen(
+                        initialSongId = song.id,
+                        topics = SongFilter.NONE.topics,
+                        songbooks = song.songbook?.let { listOf(it) }
+                            ?: SongFilter.NONE.songbooks,
+                        orderByTitle = SongFilter.NONE.orderByTitle,
                     )
                 )
-            }
-        }
+            },
+        )
+    }
 
-        composable<TopLevelDestination.Playlists> {
-            PlayListTabScreen {
-                navController.navigate(AddEditPlaylistDialog(playlistId = null))
-            }
-        }
-
-        composable<TopLevelDestination.More> {
-            MoreTabScreen()
+    composable<TopLevelDestination.Discover> {
+        DiscoverTabScreen { topic ->
+            val songFilter = topic.toSongFilter()
+            navController.navigate(
+                FilteredSongsScreen(
+                    topics = songFilter.topics,
+                    songbooks = songFilter.songbooks,
+                    orderByTitle = songFilter.orderByTitle,
+                )
+            )
         }
     }
+
+    composable<TopLevelDestination.Playlists> {
+        PlayListTabScreen {
+            navController.navigate(AddEditPlaylistDialog(playlistId = null, songId = null))
+        }
+    }
+
+    composable<TopLevelDestination.More> {
+        MoreTabScreen()
+    }
+}
 
 private fun TopicEntity.toSongFilter(): SongFilter {
     return SongFilter(
@@ -117,6 +118,6 @@ private fun TopicEntity.toSongFilter(): SongFilter {
 
 internal fun NavDestination.isATopLevelDestination(): Boolean =
     hasRoute<TopLevelDestination.Home>() ||
-        hasRoute<TopLevelDestination.Playlists>() ||
-        hasRoute<TopLevelDestination.Discover>() ||
-        hasRoute<TopLevelDestination.More>()
+            hasRoute<TopLevelDestination.Playlists>() ||
+            hasRoute<TopLevelDestination.Discover>() ||
+            hasRoute<TopLevelDestination.More>()

--- a/shared/src/commonMain/kotlin/com/techbeloved/hymnbook/shared/ui/navigation/NavigationGraph.kt
+++ b/shared/src/commonMain/kotlin/com/techbeloved/hymnbook/shared/ui/navigation/NavigationGraph.kt
@@ -41,6 +41,7 @@ private fun NavGraphBuilder.searchScreenDestination(navController: NavHostContro
                     topics = SongFilter.NONE.topics,
                     songbooks = SongFilter.NONE.songbooks,
                     orderByTitle = SongFilter.NONE.orderByTitle,
+                    playlistIds = SongFilter.NONE.playlistIds,
                 )
             )
         })
@@ -58,6 +59,7 @@ private fun NavGraphBuilder.filteredSongsScreenDestination(navController: NavHos
                         topics = route.topics,
                         songbooks = route.songbooks,
                         orderByTitle = route.orderByTitle,
+                        playlistIds = route.playlistIds,
                     )
                 )
             }

--- a/shared/src/commonMain/kotlin/com/techbeloved/hymnbook/shared/ui/playlist/PlayListTabScreen.kt
+++ b/shared/src/commonMain/kotlin/com/techbeloved/hymnbook/shared/ui/playlist/PlayListTabScreen.kt
@@ -3,6 +3,7 @@
 package com.techbeloved.hymnbook.shared.ui.playlist
 
 import androidx.compose.foundation.Canvas
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.BoxWithConstraints
 import androidx.compose.foundation.layout.Column
@@ -13,6 +14,7 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.twotone.PlaylistAdd
@@ -67,6 +69,7 @@ internal fun PlayListTabScreen(
     modifier: Modifier = Modifier,
     viewModel: PlaylistsViewModel = viewModel(factory = PlaylistsViewModel.Factory),
     onAddPlaylistClick: () -> Unit,
+    onOpenPlaylistDetail: (item: PlaylistItem) -> Unit,
 ) {
 
     val state by viewModel.state.collectAsStateWithLifecycle()
@@ -75,6 +78,7 @@ internal fun PlayListTabScreen(
         onAddPlaylistClick = onAddPlaylistClick,
         onDelete = viewModel::onDeletePlaylist,
         modifier = modifier,
+        onItemClick = onOpenPlaylistDetail,
     )
 }
 
@@ -83,6 +87,7 @@ private fun PlaylistsUi(
     state: PlaylistsUiState,
     onAddPlaylistClick: () -> Unit,
     onDelete: (PlaylistItem) -> Unit,
+    onItemClick: (PlaylistItem) -> Unit,
     modifier: Modifier = Modifier,
 ) {
     val scrollBehavior = TopAppBarDefaults.pinnedScrollBehavior()
@@ -136,10 +141,11 @@ private fun PlaylistsUi(
                 contentPadding = innerPadding,
                 state = listState,
             ) {
-                items(state.playlists.size) {
+                items(items = state.playlists, key = { it.id }) { item ->
                     PlaylistItem(
-                        item = state.playlists[it],
-                        onDeleteClick = { onDelete(state.playlists[it]) },
+                        item = item,
+                        onDeleteClick = { onDelete(item) },
+                        onItemClick = { onItemClick(item) },
                     )
                 }
             }
@@ -157,6 +163,7 @@ private fun PlaylistsUiPreview() {
         created = Instant.DISTANT_PAST,
         updated = Instant.DISTANT_PAST,
         imageUrl = null,
+        songCount = 10L,
     )
     val item2 = PlaylistItem(
         id = 2L,
@@ -165,11 +172,12 @@ private fun PlaylistsUiPreview() {
         created = Instant.DISTANT_PAST,
         updated = Instant.DISTANT_PAST,
         imageUrl = null,
+        songCount = 5L,
     )
     val state =
-        PlaylistsUiState(playlists = kotlinx.collections.immutable.persistentListOf(item1, item2))
+        PlaylistsUiState(playlists = persistentListOf(item1, item2))
     AppTheme {
-        PlaylistsUi(state = state, onAddPlaylistClick = { }, onDelete = {})
+        PlaylistsUi(state = state, onAddPlaylistClick = { }, onDelete = {}, onItemClick = {})
     }
 }
 
@@ -183,6 +191,7 @@ private fun PlaylistsUiPreviewDark() {
         created = Instant.DISTANT_PAST,
         updated = Instant.DISTANT_PAST,
         imageUrl = null,
+        songCount = 10L,
     )
     val item2 = PlaylistItem(
         id = 2L,
@@ -191,11 +200,12 @@ private fun PlaylistsUiPreviewDark() {
         created = Instant.DISTANT_PAST,
         updated = Instant.DISTANT_PAST,
         imageUrl = null,
+        songCount = 5L,
     )
     val state =
-        PlaylistsUiState(playlists = kotlinx.collections.immutable.persistentListOf(item1, item2))
+        PlaylistsUiState(playlists = persistentListOf(item1, item2))
     AppTheme(darkTheme = true) {
-        PlaylistsUi(state = state, onAddPlaylistClick = { }, onDelete = {})
+        PlaylistsUi(state = state, onAddPlaylistClick = { }, onDelete = {}, onItemClick = {})
     }
 }
 
@@ -238,6 +248,7 @@ private fun PlaylistsEmptyUiPreview() {
             onAddPlaylistClick = {},
             onDelete = {},
             state = PlaylistsUiState(playlists = persistentListOf()),
+            onItemClick = {},
         )
     }
 }
@@ -246,21 +257,20 @@ private fun PlaylistsEmptyUiPreview() {
 private fun PlaylistItem(
     item: PlaylistItem,
     onDeleteClick: () -> Unit,
+    onItemClick: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
     var showDeleteConfirmation by remember { mutableStateOf(false) }
     ListItem(
         headlineContent = { Text(text = item.name) },
-        supportingContent = item.description?.let {
-            {
-                Text(
-                    text = it,
-                    maxLines = 2,
-                    overflow = TextOverflow.Ellipsis,
-                )
-            }
+        supportingContent = {
+            Text(
+                text = "${item.songCount} Songs",
+                maxLines = 2,
+                overflow = TextOverflow.Ellipsis,
+            )
         },
-        modifier = modifier,
+        modifier = modifier.clickable(onClick = onItemClick),
         trailingContent = {
             PlaylistItemMoreMenu(
                 onDeleteClick = { showDeleteConfirmation = true },
@@ -341,9 +351,10 @@ private fun PlaylistItemPreview() {
         imageUrl = null,
         created = Instant.DISTANT_PAST,
         updated = Instant.DISTANT_PAST,
+        songCount = 10L,
     )
     AppTheme {
-        PlaylistItem(item = item, onDeleteClick = {})
+        PlaylistItem(item = item, onDeleteClick = {}, onItemClick = {})
     }
 }
 

--- a/shared/src/commonMain/kotlin/com/techbeloved/hymnbook/shared/ui/playlist/add/AddEditPlaylistDialog.kt
+++ b/shared/src/commonMain/kotlin/com/techbeloved/hymnbook/shared/ui/playlist/add/AddEditPlaylistDialog.kt
@@ -32,20 +32,21 @@ import kotlinx.serialization.Serializable
 @Serializable
 internal data class AddEditPlaylistDialog(
     val playlistId: Long?,
+    val songId: Long?,
 )
 
 @Composable
 internal fun AddEditPlaylistDialog(
-    onDismiss: (savedPlaylistId: Long?) -> Unit,
+    onDismiss: (saved: PlaylistSaved?) -> Unit,
     modifier: Modifier = Modifier,
     viewModel: AddEditPlaylistViewModel = viewModel(factory = AddEditPlaylistViewModel.Factory),
 ) {
 
     val state by viewModel.state.collectAsStateWithLifecycle(context = Dispatchers.Main.immediate)
 
-    LaunchedEffect(state.savedPlaylistId) {
-        if (state.savedPlaylistId != null) {
-            onDismiss(state.savedPlaylistId)
+    LaunchedEffect(state.playlistSaved) {
+        if (state.playlistSaved != null) {
+            onDismiss(state.playlistSaved)
         }
     }
 

--- a/shared/src/commonMain/kotlin/com/techbeloved/hymnbook/shared/ui/playlist/add/AddEditPlaylistState.kt
+++ b/shared/src/commonMain/kotlin/com/techbeloved/hymnbook/shared/ui/playlist/add/AddEditPlaylistState.kt
@@ -9,10 +9,14 @@ internal data class AddEditPlaylistState(
     val imageUrl: String? = null,
     val isNewPlaylist: Boolean = oldItem == null,
     val isLoading: Boolean = false,
-    val savedPlaylistId: Long? = null,
+    val playlistSaved: PlaylistSaved? = null,
 ) {
     val isModified: Boolean = (name.isNotBlank()) && (oldItem?.name != name
             || oldItem.description != description
             || oldItem.imageUrl != imageUrl)
 
 }
+
+internal data class PlaylistSaved(
+    val songAdded: Boolean = false,
+)

--- a/shared/src/commonMain/kotlin/com/techbeloved/hymnbook/shared/ui/playlist/select/AddSongToPlaylistDialog.kt
+++ b/shared/src/commonMain/kotlin/com/techbeloved/hymnbook/shared/ui/playlist/select/AddSongToPlaylistDialog.kt
@@ -1,0 +1,103 @@
+@file:OptIn(ExperimentalMaterial3Api::class)
+
+package com.techbeloved.hymnbook.shared.ui.playlist.select
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.twotone.Add
+import androidx.compose.material3.Button
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.FilledTonalIconButton
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.ModalBottomSheet
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.ExperimentalComposeUiApi
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.unit.dp
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import androidx.lifecycle.viewmodel.compose.viewModel
+import kotlinx.serialization.Serializable
+
+@OptIn(ExperimentalComposeUiApi::class)
+@Serializable
+internal data class AddSongToPlaylistDialog(
+    val songId: Long,
+)
+
+@Composable
+internal fun AddSongToPlaylistDialog(
+    onDismiss: (successMessage: String?) -> Unit,
+    onCreateNewPlaylist: () -> Unit,
+    modifier: Modifier = Modifier,
+    viewModel: AddSongToPlaylistViewModel = viewModel(factory = AddSongToPlaylistViewModel.Factory),
+) {
+
+    val state by viewModel.state.collectAsStateWithLifecycle()
+
+    ModalBottomSheet(
+        onDismissRequest = { onDismiss(null) },
+        modifier = modifier,
+        scrimColor = Color.Transparent,
+    ) {
+        Text(
+            text = "Add Song to Playlist",
+            style = MaterialTheme.typography.titleMedium,
+            modifier = Modifier.align(Alignment.CenterHorizontally),
+        )
+        HorizontalDivider()
+        Spacer(Modifier.height(16.dp))
+
+        Button(
+            onClick = { onCreateNewPlaylist() },
+            modifier = Modifier.align(Alignment.CenterHorizontally),
+        ) {
+            Row {
+                Text("Create a new playlist")
+                Spacer(Modifier.width(8.dp))
+                Icon(imageVector = Icons.TwoTone.Add, contentDescription = null)
+            }
+        }
+
+        LazyColumn(
+            horizontalAlignment = Alignment.CenterHorizontally,
+            modifier = Modifier.fillMaxWidth(),
+            contentPadding = PaddingValues(16.dp),
+        ) {
+
+            items(state.playlists, key = { it.id }) { playlist ->
+                Column {
+                    Row(modifier = Modifier.fillMaxWidth()) {
+                        Text(playlist.name)
+                        Spacer(Modifier.weight(1f))
+                        FilledTonalIconButton(
+                            onClick = {
+                                viewModel.onSelectPlaylist(playlist.id)
+                                onDismiss("Song added to playlist - ${playlist.name}")
+                            }
+                        ) {
+                            Icon(
+                                imageVector = Icons.TwoTone.Add,
+                                contentDescription = "Add song to ${playlist.name}"
+                            )
+                        }
+                    }
+                    Spacer(Modifier.height(16.dp))
+                }
+            }
+        }
+    }
+}

--- a/shared/src/commonMain/kotlin/com/techbeloved/hymnbook/shared/ui/playlist/select/AddSongToPlaylistState.kt
+++ b/shared/src/commonMain/kotlin/com/techbeloved/hymnbook/shared/ui/playlist/select/AddSongToPlaylistState.kt
@@ -1,0 +1,9 @@
+package com.techbeloved.hymnbook.shared.ui.playlist.select
+
+import com.techbeloved.hymnbook.shared.model.playlist.PlaylistItem
+import kotlinx.collections.immutable.ImmutableList
+
+internal data class AddSongToPlaylistState(
+    val playlists: ImmutableList<PlaylistItem>,
+    val songToAdd: Long,
+)

--- a/shared/src/commonMain/kotlin/com/techbeloved/hymnbook/shared/ui/playlist/select/AddSongToPlaylistViewModel.kt
+++ b/shared/src/commonMain/kotlin/com/techbeloved/hymnbook/shared/ui/playlist/select/AddSongToPlaylistViewModel.kt
@@ -1,0 +1,61 @@
+package com.techbeloved.hymnbook.shared.ui.playlist.select
+
+import androidx.lifecycle.SavedStateHandle
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.createSavedStateHandle
+import androidx.lifecycle.viewModelScope
+import androidx.lifecycle.viewmodel.initializer
+import androidx.lifecycle.viewmodel.viewModelFactory
+import androidx.navigation.toRoute
+import com.techbeloved.hymnbook.shared.di.appComponent
+import com.techbeloved.hymnbook.shared.model.playlist.PlaylistItem
+import com.techbeloved.hymnbook.shared.playlist.AddSongToPlaylistUseCase
+import com.techbeloved.hymnbook.shared.playlist.GetPlaylistsUseCase
+import kotlinx.collections.immutable.toImmutableList
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.stateIn
+import kotlinx.coroutines.launch
+import me.tatarka.inject.annotations.Assisted
+import me.tatarka.inject.annotations.Inject
+
+internal class AddSongToPlaylistViewModel @Inject constructor(
+    private val addSongToPlaylistUseCase: AddSongToPlaylistUseCase,
+    getPlaylistsUseCase: GetPlaylistsUseCase,
+    @Assisted savedStateHandle: SavedStateHandle,
+) : ViewModel() {
+
+    private val args = savedStateHandle.toRoute<AddSongToPlaylistDialog>()
+
+    val state = getPlaylistsUseCase().map { playlists ->
+        AddSongToPlaylistState(
+            playlists = playlists.toImmutableList(),
+            songToAdd = args.songId,
+        )
+    }.stateIn(
+        scope = viewModelScope,
+        started = SharingStarted.WhileSubscribed(stopTimeoutMillis = 5_000),
+        initialValue = AddSongToPlaylistState(
+            playlists = emptyList<PlaylistItem>().toImmutableList(),
+            songToAdd = args.songId,
+        )
+    )
+
+    fun onSelectPlaylist(playlistId: Long) {
+        viewModelScope.launch {
+            addSongToPlaylistUseCase(songId = args.songId, playlistId = playlistId)
+        }
+    }
+
+    @Inject
+    class Factory(val create: (SavedStateHandle) -> AddSongToPlaylistViewModel)
+
+    companion object {
+
+        val Factory = viewModelFactory {
+            initializer {
+                appComponent.addSongToPlaylistViewModelFactory().create(createSavedStateHandle())
+            }
+        }
+    }
+}

--- a/shared/src/commonMain/kotlin/com/techbeloved/hymnbook/shared/ui/settings/NowPlayingSettingsBottomSheet.kt
+++ b/shared/src/commonMain/kotlin/com/techbeloved/hymnbook/shared/ui/settings/NowPlayingSettingsBottomSheet.kt
@@ -8,10 +8,13 @@ import androidx.compose.foundation.layout.RowScope
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.twotone.PlaylistAdd
 import androidx.compose.material.icons.filled.Add
 import androidx.compose.material.icons.filled.Remove
 import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.FilledTonalButton
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
@@ -40,6 +43,7 @@ internal fun NowPlayingSettingsBottomSheet(
     onZoomOut: () -> Unit,
     onZoomIn: () -> Unit,
     onChangeSongDisplayMode: (songDisplayMode: SongDisplayMode) -> Unit,
+    onAddSongToPlaylist: () -> Unit,
     preferences: SongPreferences,
     playbackSpeed: Int,
     modifier: Modifier = Modifier,
@@ -50,6 +54,26 @@ internal fun NowPlayingSettingsBottomSheet(
         sheetState = bottomSheetState,
         modifier = modifier,
     ) {
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.spacedBy(
+                space = 16.dp,
+                alignment = Alignment.CenterHorizontally,
+            )
+        ) {
+            FilledTonalButton(
+                onClick = onAddSongToPlaylist,
+            ) {
+                Row {
+                    Text(text = "Add to playlist")
+                    Spacer(Modifier.width(8.dp))
+                    Icon(
+                        imageVector = Icons.AutoMirrored.TwoTone.PlaylistAdd,
+                        contentDescription = "Add to playlist",
+                    )
+                }
+            }
+        }
         SheetMusicToggle(
             songDisplayMode = preferences.songDisplayMode,
             onToggle = onChangeSongDisplayMode,

--- a/shared/src/commonMain/kotlin/com/techbeloved/hymnbook/shared/ui/songs/FilteredSongsScreen.kt
+++ b/shared/src/commonMain/kotlin/com/techbeloved/hymnbook/shared/ui/songs/FilteredSongsScreen.kt
@@ -27,9 +27,16 @@ import kotlinx.serialization.Serializable
 internal data class FilteredSongsScreen(
     val topics: List<String>,
     val songbooks: List<String>,
+    val playlistIds: List<Long>,
     val orderByTitle: Boolean,
+    val title: String = "",
 ) {
-    val songFilter get() = SongFilter(topics, songbooks, orderByTitle)
+    val songFilter get() = SongFilter(
+        topics = topics,
+        songbooks = songbooks,
+        playlistIds = playlistIds,
+        orderByTitle = orderByTitle,
+    )
 }
 
 @Composable
@@ -63,7 +70,7 @@ private fun FilteredSongsUi(
                 scrollBehaviour = scrollBehavior,
                 containerColor = MaterialTheme.colorScheme.surface.copy(alpha = .5f),
                 modifier = Modifier.hazeEffect(hazeState, style = HazeMaterials.ultraThin()),
-                title = state.filter.topics.firstOrNull().orEmpty(),
+                title = state.title,
             )
         },
         modifier = modifier,

--- a/shared/src/commonMain/kotlin/com/techbeloved/hymnbook/shared/ui/songs/FilteredSongsState.kt
+++ b/shared/src/commonMain/kotlin/com/techbeloved/hymnbook/shared/ui/songs/FilteredSongsState.kt
@@ -7,4 +7,5 @@ import kotlinx.collections.immutable.ImmutableList
 internal data class FilteredSongsState(
     val filter: SongFilter,
     val songs: ImmutableList<SongTitle>,
+    val title: String,
 )

--- a/shared/src/commonMain/kotlin/com/techbeloved/hymnbook/shared/ui/songs/FilteredSongsViewModel.kt
+++ b/shared/src/commonMain/kotlin/com/techbeloved/hymnbook/shared/ui/songs/FilteredSongsViewModel.kt
@@ -22,15 +22,26 @@ internal class FilteredSongsViewModel @Inject constructor(
     @Assisted savedStateHandle: SavedStateHandle,
     private val getFilteredSongTitlesUseCase: GetFilteredSongTitlesUseCase,
 ) : ViewModel() {
-    private val songFilter = savedStateHandle.toRoute<FilteredSongsScreen>().songFilter
+    private val args = savedStateHandle.toRoute<FilteredSongsScreen>()
+    private val songFilter = args.songFilter
 
     val state: StateFlow<FilteredSongsState> = flow {
         val songs = getFilteredSongTitlesUseCase.invoke(songFilter)
-        emit(FilteredSongsState(filter = songFilter, songs = songs.toImmutableList()))
+        emit(
+            FilteredSongsState(
+                filter = songFilter,
+                songs = songs.toImmutableList(),
+                title = args.title,
+            )
+        )
     }.stateIn(
         scope = viewModelScope,
         started = SharingStarted.WhileSubscribed(stopTimeoutMillis = 5_000),
-        initialValue = FilteredSongsState(songFilter, emptyList<SongTitle>().toImmutableList()),
+        initialValue = FilteredSongsState(
+            filter = songFilter,
+            songs = emptyList<SongTitle>().toImmutableList(),
+            title = args.title,
+        ),
     )
 
     @Inject

--- a/shared/src/commonMain/sqldelight/com/techbeloved/hymnbook/PlaylistEntity.sq
+++ b/shared/src/commonMain/sqldelight/com/techbeloved/hymnbook/PlaylistEntity.sq
@@ -24,12 +24,31 @@ lastInsertRowId:
 SELECT last_insert_rowid();
 
 getAll:
-SELECT * FROM PlaylistEntity
+SELECT
+    pl.id,
+    pl.name,
+    pl.description,
+    pl.image_url,
+    pl.created,
+    pl.modified,
+    COUNT(ps.song_id) AS song_count
+FROM PlaylistEntity AS pl
+LEFT OUTER JOIN PlaylistSongs AS ps ON ps.playlist_id = pl.id
+GROUP BY pl.id
 ORDER BY created;
 
 getById:
-SELECT * FROM PlaylistEntity
-WHERE id = :playlistId;
+SELECT
+    pl.id,
+    pl.name,
+    pl.description,
+    pl.image_url,
+    pl.created,
+    pl.modified,
+    COUNT(ps.song_id) AS song_count
+FROM PlaylistEntity AS pl
+LEFT OUTER JOIN PlaylistSongs AS ps ON ps.playlist_id = pl.id
+WHERE pl.id = :playlistId;
 
 delete:
 DELETE FROM PlaylistEntity

--- a/shared/src/commonMain/sqldelight/com/techbeloved/hymnbook/SongEntity.sq
+++ b/shared/src/commonMain/sqldelight/com/techbeloved/hymnbook/SongEntity.sq
@@ -127,6 +127,19 @@ AND sbs.songbook IN :songbookNames
 GROUP BY sd.id
 ORDER BY (CASE WHEN :orderByTitle THEN sd.title ELSE CAST(sbs.entry AS REAL) END);
 
+filterSongsByPlaylists:
+SELECT DISTINCT sd.id, sd.title, sd.alternate_title, sbs.songbook, sbs.entry
+FROM SongDetail AS sd
+JOIN (
+    SELECT pls.playlist_id  AS playlist_id , pl.created, pls.song_id AS songid
+    FROM PlaylistSongs AS pls, PlaylistEntity AS pl
+    WHERE pls.playlist_id = pl.id
+    ) AS ps ON sd.id = ps.songid
+LEFT JOIN SongbookSongs AS sbs ON sd.id = sbs.song_id
+WHERE ps.playlist_id IN :playlistIds
+GROUP BY sd.id
+ORDER BY ps.created;
+
 
 filterSongs:
 SELECT DISTINCT sd.id, sd.title, sd.alternate_title, sbs.songbook, sbs.entry
@@ -135,9 +148,6 @@ LEFT JOIN TopicSongs AS ts ON sd.id = ts.song_id
 LEFT JOIN SongbookSongs AS sbs ON sd.id = sbs.song_id
 GROUP BY sd.id
 ORDER BY (CASE WHEN :orderByTitle THEN sd.title ELSE CAST(sbs.entry AS REAL) END);
-
-getAllSongs:
-SELECT * FROM SongDetail;
 
 getSongById:
 SELECT * FROM SongDetail


### PR DESCRIPTION
Feat: Implement "Add Song to Playlist" functionality

Feat: Implement playlist detail view and song count

Refactor: Simplify Home navigation routing



This commit introduces the ability for users to add songs to new or existing playlists.

Key changes:

- **"Add Song to Playlist" Dialog:**
    - Created `AddSongToPlaylistDialog` composable (modal bottom sheet) that allows users to select an existing playlist or create a new one to add the current song.
    - `AddSongToPlaylistViewModel` manages the state of this dialog, fetching available playlists and handling the addition of the song to the selected playlist.
    - Navigating to `AddSongToPlaylistDialog` via a new route, passing the `songId`.

- **Integration in Song Detail Screen:**
    - Added an "Add to playlist" button in the `NowPlayingSettingsBottomSheet` within the `SongDetailScreen`.
    - Tapping this button now opens the `AddSongToPlaylistDialog`.
    - `SongDetailScreen` now has an `onAddSongToPlaylist` callback to trigger navigation to the dialog.

- **Create New Playlist from Dialog:**
    - If a user chooses to create a new playlist from the `AddSongToPlaylistDialog`, they are navigated to the `AddEditPlaylistDialog`.
    - The `songId` is passed to `AddEditPlaylistDialog` so that the song can be automatically added to the newly created playlist.
    - `AddEditPlaylistViewModel` now handles adding the song if a `songId` is provided when creating a new playlist.

- **Navigation and Snackbar:**
    - Updated navigation graph in `NavigationGraph.kt` to include the route for `AddSongToPlaylistDialog`.
    - Implemented snackbar notifications to provide feedback to the user (e.g., "Song added to playlist - [Playlist Name]", "Song added to new playlist successfully").
    - The main `App` composable now includes a `SnackbarHost` to display these messages.

- **Use Cases and Database:**
    - Introduced `AddSongToPlaylistUseCase` to handle the logic of inserting a song into a playlist in the database.
    - `PlaylistSongs.sq` (implicitly, via the use case) will be used to store song-playlist associations.

- **State Management:**
    - `AddSongToPlaylistState` was created to manage the state for the new dialog.
    - `AddEditPlaylistState` was updated to include `playlistSaved` (which contains a boolean `songAdded`) to track if a song was added during playlist creation/editing.

- **Minor Refinements:**
    - The `addHomeRoutes` in `HomeGraph.kt` was updated to pass `null` for `songId` when navigating to `AddEditPlaylistDialog` from the Playlists tab, as no specific song is being added in that context.