### PR TITLE
Feat: Implement bundled assets import using manifest

### DIFF
--- a/shared/src/commonMain/composeResources/files/json/sample_hymns.json
+++ b/shared/src/commonMain/composeResources/files/json/sample_hymns.json
@@ -1,0 +1,156 @@
+{
+  "metadata": {
+    "title": "HSCF",
+    "longer_title": "Select Hymns and Songs for Christian Fellowship",
+    "publisher": "Watchman Catholic Charismatic Renewal Movement",
+    "publish_date": "1999",
+    "revision": "1"
+  },
+  "topics": [
+    {
+      "id": 1,
+      "topic": "Worship and Thanksgiving"
+    },
+    {
+      "id": 2,
+      "topic": "The Lord Jesus Christ"
+    },
+    {
+      "id": 3,
+      "topic": "The Word of God"
+    },
+    {
+      "id": 4,
+      "topic": "Admonition"
+    },
+    {
+      "id": 5,
+      "topic": "Invitation"
+    },
+    {
+      "id": 6,
+      "topic": "Repentance, Grace and Forgiveness"
+    },
+    {
+      "id": 7,
+      "topic": "Assurance and Confidence"
+    },
+    {
+      "id": 8,
+      "topic": "Love, Care and Guidance"
+    },
+    {
+      "id": 9,
+      "topic": "Holiness"
+    },
+    {
+      "id": 10,
+      "topic": "Consecration and Commitment"
+    },
+    {
+      "id": 11,
+      "topic": "Evangelism"
+    },
+    {
+      "id": 12,
+      "topic": "The Holy Spirit"
+    },
+    {
+      "id": 13,
+      "topic": "Christian Life, Service and Reward"
+    },
+    {
+      "id": 14,
+      "topic": "Prayer"
+    },
+    {
+      "id": 15,
+      "topic": "Conflict and Victory"
+    },
+    {
+      "id": 16,
+      "topic": "Closing Hymn"
+    },
+    {
+      "id": 17,
+      "topic": "Death and Resurrection"
+    },
+    {
+      "id": 18,
+      "topic": "The Second Coming of Christ"
+    },
+    {
+      "id": 19,
+      "topic": "Heaven"
+    },
+    {
+      "id": 20,
+      "topic": "Warning and Judgment"
+    },
+    {
+      "id": 21,
+      "topic": "Youth Fellowship"
+    }
+  ],
+  "songs": [
+    {
+      "title": "Oh for a thousand tongues to sing",
+      "num": 1,
+      "verses": [
+        "Oh for a thousand tongues to sing\nMy great Redeemer's praise,\nThe glories of my God and king,\nThe triumphs of His grace!",
+        "My gracious master and my God,\nAssist me to proclaim,\nTo spread through all the earth abroad\nThe honors of Thy name.",
+        "Jesus! the name that charms our fears,\nThat bids our sorrows cease;\n'Tis music in the sinner's ears,\n'Tis life, and health, and peace.",
+        "He breaks the power of canceled sin,\nHe sets the prisoner free;\nHis blood can make the foulest clean,\nHis blood availed for me.",
+        "Hear Him, ye deaf; His praise, ye dumb,\nYour loosened tongues employ;\nYe blind, behold your Savior come,\nAnd leap, ye lame, for joy.",
+        "Glory to God, and praise and love\nBe ever, ever given,\nBy saints below and saints above,\nThe church in earth and Heaven."
+      ],
+      "chorus": null,
+      "id": "hymn_1",
+      "attribution": {
+        "credits": null,
+        "music_by": "Azmon Carl G. Gläser, 1828; arranged by Lowell Mason, Modern Psalmist, 1839 .",
+        "lyrics_by": "Charles Wesley, 1739. Wesley wrote this hymn to commemorate the first anniversary of his conversion to Christ. He notes in his Journal:"
+      },
+      "topic": 1,
+      "first": "O for a thousand tongues to sing\nMy great Redeemer's praise,\nThe glories of my God and king,\nThe triumphs of His grace!"
+    },
+    {
+      "title": "Praise to the Lord, the Almighty",
+      "num": 2,
+      "verses": [
+        "Praise to the Lord, the Almighty, the king of creation!\nO my soul, praise Him, for He is thy health and salvation!\nAll ye who hear, now to His temple draw near;\nPraise Him in glad adoration.",
+        "Praise to the Lord, who over all things so wondrously reigneth,\nShelters thee under His wings, yea, so gently sustaineth!\nHast thou not seen how thy desires ever have been\nGranted in what He ordaineth?",
+        "Praise to the Lord, who doth prosper thy work and defend thee;\nSurely His goodness and mercy here daily attend thee.\nPonder anew what the Almighty can do,\nIf with His love He befriend thee.",
+        "Praise to the Lord , who with marvelous wisdom hath made thee!\nDecked thee with health, and with loving hand guided and stayed thee;\nHow oft in grief\nHath not He brought thee relief, \nSpreading His wings for thee to shade thee!",
+        "Praise to the Lord, O let all that is in me adore Him!\nAll that hath life and breath, come now with praises before Him.\nLet the Amen sound from His people again,\nGladly for aye we adore Him."
+      ],
+      "chorus": null,
+      "id": "hymn_2",
+      "attribution": {
+        "credits": null,
+        "music_by": "Lobe den Herren Ander Theil des Erneuerten Gesangbuch, second edition (Bremen, Germany: 1665); harmony by William S. Bennett, 1864 .",
+        "lyrics_by": "Joachim Neander, in A und Ω Glaub- und Liebesübung (Stralsund: 1680) (Lobe den Herren); translated from German to English by Catherine Winkworth, 1863."
+      },
+      "topic": 1,
+      "first": "Praise to the Lord, the Almighty, the king of creation!\nO my soul, praise Him, for He is thy health and salvation!\nAll ye who hear, now to His temple draw near;\nPraise Him in glad adoration."
+    },
+    {
+      "title": "To God be the Glory",
+      "num": 3,
+      "verses": [
+        "To God be the glory, great things He has done;\nSo loved He the world that He gave us His Son,\nWho yielded His life an atonement for sin,\nAnd opened the life gate that all may go in.",
+        "Oh perfect redemption, the purchase of blood,\nTo every believer the promise of God;\nThe vilest offender who truly believes,\nThat moment from Jesus a pardon receives.",
+        "Great things He has taught us, great things He has done,\nAnd great our rejoicing through Jesus the Son;\nBut purer, and higher, and greater will be\nOur wonder, our transport, when Jesus we see."
+      ],
+      "chorus": "Praise the Lord, praise the Lord,\nLet the earth hear His voice!\nPraise the Lord, praise the Lord,\nLet the people rejoice!\nO come to the Father, through Jesus the Son,\nAnd give Him the glory, great things He has done.",
+      "id": "hymn_3",
+      "attribution": {
+        "credits": null,
+        "music_by": "W. Howard Doane .",
+        "lyrics_by": "Fanny Crosby, in Brightest and Best, by W. H. Doane & Robert Lowry (Chicago, Illinois: Biglow & Main, 1875), number 118."
+      },
+      "topic": 1,
+      "first": "To God be the glory, great things He has done;\nSo loved He the world that He gave us His Son,\nWho yielded His life an atonement for sin,\nAnd opened the life gate that all may go in."
+    }
+  ]
+}

--- a/shared/src/commonMain/composeResources/files/manifest/filesmanifest.json
+++ b/shared/src/commonMain/composeResources/files/manifest/filesmanifest.json
@@ -1,0 +1,26 @@
+{
+  "openlyrics": [
+    {
+      "path": "openlyrics/sample_songs.zip",
+      "type": "zip"
+    }
+  ],
+  "json": [
+    {
+      "path": "json/sample_hymns.json",
+      "type": "json"
+    }
+  ],
+  "tunes": [
+    {
+      "path": "tunes/sample_tunes.zip",
+      "type": "zip"
+    }
+  ],
+  "sheets": [
+    {
+      "path": "sheets/sample_sheets.zip",
+      "type": "zip"
+    }
+  ]
+}

--- a/shared/src/commonMain/kotlin/com/techbeloved/hymnbook/shared/assetimport/ImportBundledAssetsUseCase.kt
+++ b/shared/src/commonMain/kotlin/com/techbeloved/hymnbook/shared/assetimport/ImportBundledAssetsUseCase.kt
@@ -1,0 +1,147 @@
+package com.techbeloved.hymnbook.shared.assetimport
+
+import com.techbeloved.hymnbook.shared.dispatcher.DispatchersProvider
+import com.techbeloved.hymnbook.shared.ext.sheetsDir
+import com.techbeloved.hymnbook.shared.ext.tunesDir
+import com.techbeloved.hymnbook.shared.files.AssetFileSourceProvider
+import com.techbeloved.hymnbook.shared.files.ExtractArchiveUseCase
+import com.techbeloved.hymnbook.shared.files.GetSavedFileHashUseCase
+import com.techbeloved.hymnbook.shared.files.HashAssetFileUseCase
+import com.techbeloved.hymnbook.shared.files.OkioFileSystemProvider
+import com.techbeloved.hymnbook.shared.files.SaveFileHashUseCase
+import com.techbeloved.hymnbook.shared.files.SharedFileSystem
+import com.techbeloved.hymnbook.shared.jsonimport.ImportJsonSongUseCase
+import com.techbeloved.hymnbook.shared.media.ImportMediaFilesUseCase
+import com.techbeloved.hymnbook.shared.model.assetimport.AssetType
+import com.techbeloved.hymnbook.shared.model.assetimport.BundledAsset
+import com.techbeloved.hymnbook.shared.model.assetimport.BundledAssetManifest
+import com.techbeloved.hymnbook.shared.openlyrics.ImportOpenLyricsUseCase
+import com.techbeloved.hymnbook.shared.sheetmusic.ImportMusicSheetsUseCase
+import kotlinx.coroutines.withContext
+import kotlinx.serialization.json.Json
+import me.tatarka.inject.annotations.Inject
+import okio.buffer
+import okio.use
+
+internal class ImportBundledAssetsUseCase @Inject constructor(
+    private val hashAssetFileUseCase: HashAssetFileUseCase,
+    private val extractArchiveUseCase: ExtractArchiveUseCase,
+    private val importOpenLyricsUseCase: ImportOpenLyricsUseCase,
+    private val importJsonSongUseCase: ImportJsonSongUseCase,
+    private val fileSystemProvider: OkioFileSystemProvider,
+    private val getSavedFileHashUseCase: GetSavedFileHashUseCase,
+    private val saveFileHashUseCase: SaveFileHashUseCase,
+    private val importMediaFilesUseCase: ImportMediaFilesUseCase,
+    private val importMusicSheetsUseCase: ImportMusicSheetsUseCase,
+    private val defaultAssetFileSourceProvider: AssetFileSourceProvider,
+    private val dispatchersProvider: DispatchersProvider,
+    private val json: Json,
+) {
+    suspend operator fun invoke() = withContext(dispatchersProvider.io()) {
+        val fileSystem = fileSystemProvider.get()
+        val manifestJson = defaultAssetFileSourceProvider.get("files/manifest/filesmanifest.json")
+            .use { fileSource ->
+                fileSource.buffer().use { bufferedSource ->
+                    bufferedSource.readUtf8()
+                }
+            }
+        val bundledAssets = json.decodeFromString(
+            deserializer = BundledAssetManifest.serializer(),
+            string = manifestJson,
+        )
+        importOpenLyrics(fileSystem, bundledAssets.openlyrics)
+        importJsonHymnbook(bundledAssets.json)
+        importTunes(fileSystem, bundledAssets.tunes)
+        importSheets(fileSystem, bundledAssets.sheets)
+    }
+
+    private suspend fun importTunes(
+        fileSystem: SharedFileSystem,
+        tunesAssets: List<BundledAsset>,
+    ) {
+        tunesAssets.filter { it.type == AssetType.ZIP }.forEach { bundledAsset ->
+            val tunesAssetFileHash = hashAssetFileUseCase(bundledAsset.fullPath)
+            val savedTunesArchiveHash = getSavedFileHashUseCase(bundledAsset.fullPath)
+            if (savedTunesArchiveHash?.sha256 != tunesAssetFileHash.sha256) {
+                val tunesDir = fileSystem.tunesDir()
+                if (!fileSystem.fileSystem.exists(tunesDir)) {
+                    fileSystem.fileSystem.createDirectory(tunesDir)
+                }
+                val result = extractArchiveUseCase(
+                    assetFilePath = bundledAsset.fullPath,
+                    destination = tunesDir,
+                ).onFailure { it.printStackTrace() }
+                if (result.isSuccess) {
+                    importMediaFilesUseCase(tunesDir).onFailure { it.printStackTrace() }
+                    saveFileHashUseCase(tunesAssetFileHash)
+                }
+            }
+        }
+    }
+
+    private suspend fun importSheets(
+        fileSystem: SharedFileSystem,
+        sheetsAssets: List<BundledAsset>,
+    ) {
+        sheetsAssets.filter { it.type == AssetType.ZIP }.forEach { bundledAsset ->
+            val sheetsAssetFileHash = hashAssetFileUseCase(bundledAsset.fullPath)
+            val savedSheetsArchiveHash = getSavedFileHashUseCase(bundledAsset.fullPath)
+
+            if (savedSheetsArchiveHash?.sha256 != sheetsAssetFileHash.sha256) {
+                val sheetsDir = fileSystem.sheetsDir()
+                if (!fileSystem.fileSystem.exists(sheetsDir)) {
+                    fileSystem.fileSystem.createDirectory(sheetsDir)
+                }
+                val result = extractArchiveUseCase(
+                    assetFilePath = bundledAsset.fullPath,
+                    destination = sheetsDir
+                ).onFailure { it.printStackTrace() }
+                if (result.isSuccess) {
+                    importMusicSheetsUseCase(sheetsDir).onFailure { it.printStackTrace() }
+                    saveFileHashUseCase(sheetsAssetFileHash)
+                }
+            }
+        }
+
+    }
+
+    private suspend fun importJsonHymnbook(
+        jsonAssets: List<BundledAsset>,
+    ) {
+        jsonAssets.filter { it.type == AssetType.JSON }.forEach { bundledAsset ->
+            val lyricsAssetFileHash = hashAssetFileUseCase(bundledAsset.fullPath)
+            val savedLyricsArchiveHash = getSavedFileHashUseCase(bundledAsset.fullPath)
+            if (savedLyricsArchiveHash?.sha256 != lyricsAssetFileHash.sha256) {
+                importJsonSongUseCase(bundledAsset.fullPath)
+                saveFileHashUseCase(lyricsAssetFileHash)
+            }
+        }
+    }
+
+    private suspend fun importOpenLyrics(
+        fileSystem: SharedFileSystem,
+        openLyricsAssets: List<BundledAsset>,
+    ) {
+        openLyricsAssets.filter { it.type == AssetType.ZIP }.forEach { bundledAsset ->
+            val lyricsAssetFileHash = hashAssetFileUseCase(bundledAsset.fullPath)
+            val savedLyricsArchiveHash = getSavedFileHashUseCase(bundledAsset.fullPath)
+            if (savedLyricsArchiveHash?.sha256 != lyricsAssetFileHash.sha256) {
+                val lyricsDir = fileSystem.tempDir / "lyrics/"
+                if (!fileSystem.fileSystem.exists(lyricsDir)) {
+                    fileSystem.fileSystem.createDirectory(lyricsDir)
+                }
+                val result = extractArchiveUseCase(
+                    assetFilePath = bundledAsset.fullPath,
+                    destination = lyricsDir,
+                )
+                if (result.isSuccess) {
+                    importOpenLyricsUseCase(lyricsDir)
+                    saveFileHashUseCase(lyricsAssetFileHash)
+                }
+                // Delete temporary files
+                fileSystem.fileSystem.deleteRecursively(lyricsDir)
+
+            }
+        }
+    }
+}

--- a/shared/src/commonMain/kotlin/com/techbeloved/hymnbook/shared/di/AppComponent.kt
+++ b/shared/src/commonMain/kotlin/com/techbeloved/hymnbook/shared/di/AppComponent.kt
@@ -21,6 +21,7 @@ import com.techbeloved.hymnbook.shared.ui.playlist.select.AddSongToPlaylistViewM
 import com.techbeloved.hymnbook.shared.ui.search.SearchScreenModel
 import com.techbeloved.hymnbook.shared.ui.songs.FilteredSongsViewModel
 import com.techbeloved.hymnbook.shared.ui.topics.TopicsViewModel
+import kotlinx.serialization.json.Json
 import me.tatarka.inject.annotations.Component
 import me.tatarka.inject.annotations.KmpComponentCreate
 import me.tatarka.inject.annotations.Provides
@@ -64,6 +65,9 @@ internal interface AppComponent {
 
     @Provides
     fun database(): Database = Injector.database
+
+    @Provides
+    fun json(): Json = Injector.json
 
     @Provides
     fun provideInstantProvider(instantProvider: DefaultInstantProvider): InstantProvider =

--- a/shared/src/commonMain/kotlin/com/techbeloved/hymnbook/shared/di/Injector.kt
+++ b/shared/src/commonMain/kotlin/com/techbeloved/hymnbook/shared/di/Injector.kt
@@ -26,7 +26,7 @@ internal object Injector {
         getDatabase(driver)
     }
 
-    private val json: Json by lazy {
+    val json: Json by lazy {
         Json {
             isLenient = true
             encodeDefaults = true

--- a/shared/src/commonMain/kotlin/com/techbeloved/hymnbook/shared/jsonimport/ImportJsonSongUseCase.kt
+++ b/shared/src/commonMain/kotlin/com/techbeloved/hymnbook/shared/jsonimport/ImportJsonSongUseCase.kt
@@ -1,0 +1,34 @@
+package com.techbeloved.hymnbook.shared.jsonimport
+
+import com.techbeloved.hymnbook.shared.dispatcher.DispatchersProvider
+import com.techbeloved.hymnbook.shared.files.AssetFileSourceProvider
+import com.techbeloved.hymnbook.shared.model.jsonimport.JsonSongbook
+import kotlinx.coroutines.withContext
+import kotlinx.serialization.json.Json
+import me.tatarka.inject.annotations.Inject
+import okio.buffer
+import okio.use
+
+internal class ImportJsonSongUseCase @Inject constructor(
+    private val dispatchersProvider: DispatchersProvider,
+    private val saveJsonSongUseCase: SaveJsonSongUseCase,
+    private val defaultAssetFileSourceProvider: AssetFileSourceProvider,
+    private val json: Json,
+) {
+    suspend operator fun invoke(jsonAssetFile: String) = withContext(dispatchersProvider.io()) {
+        runCatching {
+            val lyricsJsonContent =
+                defaultAssetFileSourceProvider.get(jsonAssetFile).use { fileSource ->
+                    fileSource.buffer().use { bufferedSource ->
+                        bufferedSource.readUtf8()
+                    }
+                }
+
+            val jsonSongbook = json.decodeFromString(
+                deserializer = JsonSongbook.serializer(),
+                string = lyricsJsonContent
+            )
+            saveJsonSongUseCase(jsonSongbook)
+        }
+    }
+}

--- a/shared/src/commonMain/kotlin/com/techbeloved/hymnbook/shared/jsonimport/SaveJsonSongUseCase.kt
+++ b/shared/src/commonMain/kotlin/com/techbeloved/hymnbook/shared/jsonimport/SaveJsonSongUseCase.kt
@@ -1,0 +1,131 @@
+package com.techbeloved.hymnbook.shared.jsonimport
+
+import com.techbeloved.hymnbook.Database
+import com.techbeloved.hymnbook.SongbookSongs
+import com.techbeloved.hymnbook.TopicSongs
+import com.techbeloved.hymnbook.shared.dispatcher.DispatchersProvider
+import com.techbeloved.hymnbook.shared.model.Lyric
+import com.techbeloved.hymnbook.shared.model.jsonimport.JsonSongLyric
+import com.techbeloved.hymnbook.shared.model.jsonimport.JsonSongbook
+import com.techbeloved.hymnbook.shared.model.jsonimport.JsonSongbookMetadata
+import com.techbeloved.hymnbook.shared.time.InstantProvider
+import kotlinx.coroutines.withContext
+import kotlinx.datetime.Instant
+import me.tatarka.inject.annotations.Inject
+
+internal class SaveJsonSongUseCase @Inject constructor(
+    private val database: Database,
+    private val dispatchersProvider: DispatchersProvider,
+    private val instantProvider: InstantProvider,
+) {
+    suspend operator fun invoke(songbook: JsonSongbook) = withContext(dispatchersProvider.io()) {
+        val created = instantProvider.get()
+        database.transaction {
+            database.songbookEntityQueries.insert(
+                name = songbook.metadata.title,
+                publisher = songbook.metadata.publisher,
+            )
+            for (topic in songbook.topics) {
+                database.topicEntityQueries.insert(topic.topic)
+            }
+            for (song in songbook.songs) {
+
+                val songId = insertOrUpdate(
+                    song = song,
+                    created = created,
+                    metadata = songbook.metadata,
+                )
+
+                // SongbookSong
+                val songbookSong = SongbookSongs(
+                    songbook = songbook.metadata.title,
+                    song_id = songId,
+                    entry = song.number.toString(),
+                )
+                database.songbookSongsQueries.insert(
+                    songbookSong.songbook,
+                    songbookSong.song_id,
+                    songbookSong.entry
+                )
+
+                // Topics
+                val topicSong = TopicSongs(
+                    topic = songbook.topics.find { it.id == song.topicId }?.topic,
+                    song_id = songId,
+                )
+
+                database.topicSongsQueries.insert(
+                    topic = topicSong.topic,
+                    song_id = topicSong.song_id,
+                )
+                // Authors
+                // Figure out how to deal with authors. Currently we only have credits, music by, and lyrics by.
+                // Which are more of comments or history.
+            }
+        }
+    }
+
+    private fun insertOrUpdate(
+        song: JsonSongLyric,
+        created: Instant,
+        metadata: JsonSongbookMetadata,
+    ): Long {
+        val existingSong = database.songEntityQueries.getSongByTitleAndSongbook(
+            title = song.title,
+            songbook = metadata.title,
+        ).executeAsOneOrNull()
+        val lyrics = lyricsFromJson(song)
+        if (existingSong == null) {
+            database.songEntityQueries.insert(
+                title = song.title,
+                alternate_title = null,
+                lyrics = lyrics,
+                verse_order = null,
+                comments = null,
+                copyright = null,
+                search_title = song.title,
+                search_lyrics = lyrics.joinToString(separator = " ") { it.content },
+                search_songbook = "${song.number}",
+                created = created,
+                modified = created,
+                id = null,
+            )
+        } else {
+            database.songEntityQueries.update(
+                title = song.title,
+                alternate_title = null,
+                lyrics = lyrics,
+                verse_order = null,
+                comments = null,
+                copyright = null,
+                search_title = song.title,
+                search_lyrics = lyrics.joinToString(separator = " ") { it.content },
+                search_songbook = "${song.number}",
+                modified = created,
+                id = existingSong.id,
+            )
+        }
+        return existingSong?.id
+            ?: database.songEntityQueries.lastInsertRowId().executeAsOne()
+    }
+
+    private fun lyricsFromJson(song: JsonSongLyric): List<Lyric> = buildList {
+        if (!song.chorus.isNullOrBlank()) {
+            add(
+                Lyric(
+                    type = Lyric.Type.Chorus,
+                    label = "c1",
+                    content = song.chorus,
+                )
+            )
+        }
+        val lyrics = song.verses.mapIndexed { index, verse ->
+            Lyric(
+                type = Lyric.Type.Verse,
+                label = "v${index + 1}",
+                content = verse,
+            )
+        }
+        addAll(lyrics)
+    }
+}

--- a/shared/src/commonMain/kotlin/com/techbeloved/hymnbook/shared/model/assetimport/BundledAssetManifest.kt
+++ b/shared/src/commonMain/kotlin/com/techbeloved/hymnbook/shared/model/assetimport/BundledAssetManifest.kt
@@ -1,0 +1,27 @@
+package com.techbeloved.hymnbook.shared.model.assetimport
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+internal data class BundledAssetManifest(
+    val openlyrics: List<BundledAsset>,
+    val json: List<BundledAsset>,
+    val tunes: List<BundledAsset>,
+    val sheets: List<BundledAsset>,
+)
+
+@Serializable
+internal data class BundledAsset(
+    val path: String,
+    val type: AssetType,
+) {
+    val fullPath get() = "files/$path"
+}
+
+internal enum class AssetType {
+    @SerialName("zip")
+    ZIP,
+    @SerialName("json")
+    JSON,
+}

--- a/shared/src/commonMain/kotlin/com/techbeloved/hymnbook/shared/model/jsonimport/JsonSongbook.kt
+++ b/shared/src/commonMain/kotlin/com/techbeloved/hymnbook/shared/model/jsonimport/JsonSongbook.kt
@@ -1,0 +1,50 @@
+package com.techbeloved.hymnbook.shared.model.jsonimport
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+internal data class JsonSongbook(
+    val metadata: JsonSongbookMetadata,
+    val topics: List<JsonSongTopic>,
+    @SerialName("songs")
+    val songs: List<JsonSongLyric>,
+)
+
+@Serializable
+internal data class JsonSongLyric(
+    val title: String,
+    @SerialName("num")
+    val number: Int,
+    val verses: List<String>,
+    val chorus: String? = null,
+    val attribution: JsonSongAttribution? = null,
+    @SerialName("topic")
+    val topicId: Int,
+)
+
+@Serializable
+internal data class JsonSongAttribution(
+    val credits: String?,
+    @SerialName("music_by")
+    val musicBy: String?,
+    @SerialName("lyrics_by")
+    val lyricsBy: String?,
+)
+
+@Serializable
+internal data class JsonSongTopic(
+    val topic: String,
+    val id: Int,
+)
+
+@Serializable
+internal data class JsonSongbookMetadata(
+    val title: String,
+    @SerialName("longer_title")
+    val longerTitle: String,
+    val publisher: String,
+    @SerialName("publish_date")
+    val publishDate: String,
+    val revision: String,
+)

--- a/shared/src/commonMain/kotlin/com/techbeloved/hymnbook/shared/ui/home/HomeScreenModel.kt
+++ b/shared/src/commonMain/kotlin/com/techbeloved/hymnbook/shared/ui/home/HomeScreenModel.kt
@@ -5,19 +5,9 @@ import androidx.lifecycle.viewModelScope
 import androidx.lifecycle.viewmodel.initializer
 import androidx.lifecycle.viewmodel.viewModelFactory
 import com.techbeloved.hymnbook.SongbookEntity
+import com.techbeloved.hymnbook.shared.assetimport.ImportBundledAssetsUseCase
 import com.techbeloved.hymnbook.shared.di.appComponent
-import com.techbeloved.hymnbook.shared.ext.sheetsDir
-import com.techbeloved.hymnbook.shared.ext.tunesDir
-import com.techbeloved.hymnbook.shared.files.ExtractArchiveUseCase
-import com.techbeloved.hymnbook.shared.files.GetSavedFileHashUseCase
-import com.techbeloved.hymnbook.shared.files.HashAssetFileUseCase
-import com.techbeloved.hymnbook.shared.files.OkioFileSystemProvider
-import com.techbeloved.hymnbook.shared.files.SaveFileHashUseCase
-import com.techbeloved.hymnbook.shared.files.SharedFileSystem
-import com.techbeloved.hymnbook.shared.media.ImportMediaFilesUseCase
 import com.techbeloved.hymnbook.shared.model.SongFilter
-import com.techbeloved.hymnbook.shared.openlyrics.ImportOpenLyricsUseCase
-import com.techbeloved.hymnbook.shared.sheetmusic.ImportMusicSheetsUseCase
 import com.techbeloved.hymnbook.shared.songbooks.GetAllSongbooksUseCase
 import com.techbeloved.hymnbook.shared.titles.GetFilteredSongTitlesUseCase
 import kotlinx.collections.immutable.toImmutableList
@@ -31,16 +21,9 @@ import kotlinx.coroutines.launch
 import me.tatarka.inject.annotations.Inject
 
 internal class HomeScreenModel @Inject constructor(
-    private val hashAssetFileUseCase: HashAssetFileUseCase,
-    private val extractArchiveUseCase: ExtractArchiveUseCase,
-    private val importOpenLyricsUseCase: ImportOpenLyricsUseCase,
+    private val importBundledAssetsUseCase: ImportBundledAssetsUseCase,
     private val getFilteredSongTitlesUseCase: GetFilteredSongTitlesUseCase,
-    private val fileSystemProvider: OkioFileSystemProvider,
-    private val getSavedFileHashUseCase: GetSavedFileHashUseCase,
-    private val saveFileHashUseCase: SaveFileHashUseCase,
-    private val importMediaFilesUseCase: ImportMediaFilesUseCase,
-    private val importMusicSheetsUseCase: ImportMusicSheetsUseCase,
-    private val getAllSongbooksUseCase: GetAllSongbooksUseCase,
+    getAllSongbooksUseCase: GetAllSongbooksUseCase,
 ) : ViewModel() {
 
     private val assetsReady = MutableStateFlow(false)
@@ -79,7 +62,7 @@ internal class HomeScreenModel @Inject constructor(
 
     init {
         viewModelScope.launch {
-            importBundledAssets()
+            importBundledAssetsUseCase()
             assetsReady.update { true }
         }
     }
@@ -90,87 +73,6 @@ internal class HomeScreenModel @Inject constructor(
 
     fun onUpdateSongbook(songbook: SongbookEntity) {
         selectedSongbook.update { songbook }
-    }
-
-    private suspend fun importBundledAssets() {
-        val fileSystem = fileSystemProvider.get()
-
-        // Lyrics assets
-        importBundledLyrics(fileSystem)
-
-        importBundledTunes(fileSystem)
-
-        importBundledSheets(fileSystem)
-    }
-
-    private suspend fun importBundledLyrics(fileSystem: SharedFileSystem) {
-        val lyricsBundledAsset =
-            "files/openlyrics/sample_songs.zip" // update the name with the final name
-        val lyricsAssetFileHash = hashAssetFileUseCase(lyricsBundledAsset)
-        val savedLyricsArchiveHash = getSavedFileHashUseCase(lyricsBundledAsset)
-
-        // Check if file has been imported already. Otherwise, we ignore
-        if (savedLyricsArchiveHash?.sha256 != lyricsAssetFileHash.sha256) {
-            val lyricsDir = fileSystem.tempDir / "lyrics/"
-            fileSystem.fileSystem.createDirectory(lyricsDir)
-
-            val result = extractArchiveUseCase(
-                assetFilePath = lyricsBundledAsset,
-                destination = lyricsDir
-            )
-            if (result.isSuccess) {
-                importOpenLyricsUseCase(lyricsDir)
-                saveFileHashUseCase(lyricsAssetFileHash)
-                // Delete temporary files
-                fileSystem.fileSystem.deleteRecursively(lyricsDir)
-            } else {
-                result.exceptionOrNull()?.printStackTrace()
-            }
-        }
-    }
-
-    private suspend fun importBundledTunes(fileSystem: SharedFileSystem) {
-        val tunesBundledAsset =
-            "files/tunes/sample_tunes.zip" // update the name with the final name
-        val tunesAssetFileHash = hashAssetFileUseCase(tunesBundledAsset)
-        val savedTunesArchiveHash = getSavedFileHashUseCase(tunesBundledAsset)
-
-        if (savedTunesArchiveHash?.sha256 != tunesAssetFileHash.sha256) {
-            val tunesDir = fileSystem.tunesDir()
-            fileSystem.fileSystem.createDirectory(tunesDir)
-
-            val result = extractArchiveUseCase(
-                assetFilePath = tunesBundledAsset,
-                destination = tunesDir
-            ).onFailure { it.printStackTrace() }
-
-            if (result.isSuccess) {
-                importMediaFilesUseCase(tunesDir).onFailure { it.printStackTrace() }
-                saveFileHashUseCase(tunesAssetFileHash)
-            }
-        }
-    }
-
-    private suspend fun importBundledSheets(fileSystem: SharedFileSystem) {
-        val sheetsBundledAsset =
-            "files/sheets/sample_sheets.zip" // update the name with the final name
-        val sheetsAssetFileHash = hashAssetFileUseCase(sheetsBundledAsset)
-        val savedTunesArchiveHash = getSavedFileHashUseCase(sheetsBundledAsset)
-
-        if (savedTunesArchiveHash?.sha256 != sheetsAssetFileHash.sha256) {
-            val sheetsDir = fileSystem.sheetsDir()
-            fileSystem.fileSystem.createDirectory(sheetsDir)
-
-            val result = extractArchiveUseCase(
-                assetFilePath = sheetsBundledAsset,
-                destination = sheetsDir
-            ).onFailure { it.printStackTrace() }
-
-            if (result.isSuccess) {
-                importMusicSheetsUseCase(sheetsDir).onFailure { it.printStackTrace() }
-                saveFileHashUseCase(sheetsAssetFileHash)
-            }
-        }
     }
 
     companion object {


### PR DESCRIPTION
Feat: Implement bundled assets import using manifest

This commit introduces a system for importing bundled assets (lyrics, tunes, sheets, JSON data) based on a manifest file (`filesmanifest.json`). This allows for more flexible and organized asset management.

Key changes:

- **`ImportBundledAssetsUseCase`:**
    - New use case responsible for reading the `filesmanifest.json`.
    - Iterates through the manifest entries for OpenLyrics, JSON, tunes, and sheets.
    - For each asset type:
        - Calculates the hash of the bundled asset file.
        - Compares it with a saved hash to determine if the asset has changed or is new.
        - If new or changed:
            - For ZIP archives (OpenLyrics, tunes, sheets):
                - Extracts the archive to the appropriate directory (temp for lyrics, persistent for tunes/sheets).
                - Invokes the corresponding import use case (e.g., `ImportOpenLyricsUseCase`, `ImportMediaFilesUseCase`, `ImportMusicSheetsUseCase`).
                - Saves the new hash of the asset file.
                - Deletes temporary lyric files after import.
            - For JSON files:
                - Invokes `ImportJsonSongUseCase`.
                - Saves the new hash of the asset file.
    - Utilizes `AssetFileSourceProvider` to read the manifest and asset files.

- **`filesmanifest.json`:**
    - New JSON file located in `shared/src/commonMain/composeResources/files/manifest/`.
    - Defines paths and types (e.g., "zip", "json") for bundled assets.
    - Includes sample entries for OpenLyrics, JSON, tunes, and sheets.

- **JSON Song Import:**
    - **`ImportJsonSongUseCase`:** New use case to read a JSON asset file, decode it into `JsonSongbook`, and save it using `SaveJsonSongUseCase`.
    - **`SaveJsonSongUseCase`:** New use case responsible for:
        - Inserting/updating songbook metadata, topics, and songs from a `JsonSongbook` object into the database.
        - Mapping JSON song data to the database schema, including lyrics, songbook associations, and topic associations.
    - **`JsonSongbook.kt`:** New data classes (`JsonSongbook`, `JsonSongLyric`, `JsonSongAttribution`, `JsonSongTopic`, `JsonSongbookMetadata`) to model the structure of the JSON hymnbook data.
    - **`sample_hymns.json`:** New sample JSON file in `shared/src/commonMain/composeResources/files/json/` demonstrating the expected format.

- **`BundledAssetManifest.kt`:**
    - New data classes (`BundledAssetManifest`, `BundledAsset`) and an enum (`AssetType`) to represent the structure of `filesmanifest.json`.

- **Dependency Injection:**
    - `AppComponent` now provides `Json` for serialization/deserialization.
    - `Injector` makes the `Json` instance available.

- **`HomeScreenModel` Refactor:**
    - Replaced direct asset import logic with a call to the new `ImportBundledAssetsUseCase`.
    - Removed individual use case dependencies for hashing, extraction, and specific asset type imports as these are now handled by `ImportBundledAssetsUseCase`.

This change centralizes the bundled asset import logic, makes it data-driven via the manifest, and introduces support for importing hymn data from JSON files.